### PR TITLE
Changing the Unofficial wiki domain to Official wiki domain.

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -39,4 +39,4 @@ $ zen
 
 ## 1Password
 
-Zen has to be manually added to the list of browsers that 1Password will communicate with. See [this wiki article](https://nixos.wiki/wiki/1Password) for more information. To enable 1Password integration, you need to add the line `.zen-wrapped` to the file `/etc/1password/custom_allowed_browsers`.
+Zen has to be manually added to the list of browsers that 1Password will communicate with. See [this wiki article](https://wiki.nixos.org/wiki/1Password) for more information. To enable 1Password integration, you need to add the line `.zen-wrapped` to the file `/etc/1password/custom_allowed_browsers`.


### PR DESCRIPTION
Changed the Unofficial wiki domain `https://nixos.wiki/` to official NixOS wiki domain which is `https://wiki.nixos.org/`