### PR TITLE
Remove Specific and Generic builds

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -13,24 +13,15 @@ inputs = {
 }
 ```
 
-## Packages
+## Integration
 
-This flake exposes two packages, corresponding to the `specific` and `generic` zen versions.
-The generic version maximizes compatibility with old CPUs and kernels by compiling it with some
-lower common denominator CFLAGS, the `specific` one targets newer CPUs and kernels but it may not
-work in your case.
-
-The `default` package is the `specific` one for backwards compatibility with older versions of the flake.
-
-Then in the `configuration.nix` in the `environment.systemPackages` add one of:
+To integrate `Zen Browser` to your nixos configuration, add the following to your `environment.systemPackages` in `configuration.nix`:
 
 ```nix
-inputs.zen-browser.packages."${system}".default
-inputs.zen-browser.packages."${system}".specific
-inputs.zen-browser.packages."${system}".generic
+inputs.zen-browser.packages."${system}"
 ```
 
-Depending on which version you want
+Afterwards you can just build your configuration and start the `Zen Browser`
 
 ```shell
 $ sudo nixos-rebuild switch

--- a/.github/update-zen-browser.bash
+++ b/.github/update-zen-browser.bash
@@ -35,13 +35,9 @@ base_url="https://github.com/zen-browser/desktop/releases/download/$upstream"
 # Modify with sed the nix file
 sed -i "s/version = \".*\"/version = \"$upstream\"/" ./flake.nix
 
-# Update the hash specific.sha256
-specific=$(nix-prefetch-url --type sha256 --unpack "$base_url/zen.linux-specific.tar.bz2")
-sed -i "s/specific.sha256 = \".*\"/specific.sha256 = \"$specific\"/" ./flake.nix
-
-# Update the hash generic.sha256
-generic=$(nix-prefetch-url --type sha256 --unpack "$base_url/zen.linux-generic.tar.bz2")
-sed -i "s/generic.sha256 = \".*\"/generic.sha256 = \"$generic\"/" ./flake.nix
+# Update the hash sha256
+hash=$(nix-prefetch-url --type sha256 --unpack "$base_url/zen.linux-x86_64.tar.bz2")
+sed -i "s/downloadUrl.sha256 = \".*\"/downloadUrl.sha256 = \"$hash\"/" ./flake.nix
 
 nix flake update
 nix build

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734424634,
-        "narHash": "sha256-cHar1vqHOOyC7f1+tVycPoWTfKIaqkoe1Q6TnKzuti4=",
+        "lastModified": 1734649271,
+        "narHash": "sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d3c42f187194c26d9f0309a8ecc469d6c878ce33",
+        "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,138 +1,132 @@
 {
   description = "Zen Browser";
 
-  inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
-  };
+  inputs = { nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable"; };
 
-  outputs = {
-    self,
-    nixpkgs,
-  }: let
-    system = "x86_64-linux";
-    version = "1.0.2-b.3";
-    downloadUrl = {
-      specific.url = "https://github.com/zen-browser/desktop/releases/download/${version}/zen.linux-specific.tar.bz2";
-      specific.sha256 = "0gjrvsq83l6424ijii2w0c43f2nkf6n04hb2bc9wf1yyq7g3s2nc";
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      version = "1.0.2-b.4";
+      downloadUrl.url =
+        "https://github.com/zen-browser/desktop/releases/download/${version}/zen.linux-x86_64.tar.bz2";
+      downloadUrl.sha256 =
+        "0vqzins5g4xx6niylzjq071vyk4djpn6a7rh1ymbx83ns0xb4lb5";
 
-      generic.url = "https://github.com/zen-browser/desktop/releases/download/${version}/zen.linux-generic.tar.bz2";
-      generic.sha256 = "1kv44fkql60rjgqcqsfdhbi4zr8bi91fkswlsk5d6mwj8nw1clmj";
-    };
+      pkgs = import nixpkgs { inherit system; };
 
-    pkgs = import nixpkgs {
-      inherit system;
-    };
+      runtimeLibs = with pkgs;
+        [
+          libGL
+          libGLU
+          libevent
+          libffi
+          libjpeg
+          libpng
+          libstartup_notification
+          libvpx
+          libwebp
+          stdenv.cc.cc
+          fontconfig
+          libxkbcommon
+          zlib
+          freetype
+          gtk3
+          libxml2
+          dbus
+          xcb-util-cursor
+          alsa-lib
+          libpulseaudio
+          pango
+          atk
+          cairo
+          gdk-pixbuf
+          glib
+          udev
+          libva
+          mesa
+          libnotify
+          cups
+          pciutils
+          ffmpeg
+          libglvnd
+          pipewire
+          speechd
+        ] ++ (with pkgs.xorg; [
+          libxcb
+          libX11
+          libXcursor
+          libXrandr
+          libXi
+          libXext
+          libXcomposite
+          libXdamage
+          libXfixes
+          libXScrnSaver
+        ]);
 
-    runtimeLibs = with pkgs;
-      [
-        libGL
-        libGLU
-        libevent
-        libffi
-        libjpeg
-        libpng
-        libstartup_notification
-        libvpx
-        libwebp
-        stdenv.cc.cc
-        fontconfig
-        libxkbcommon
-        zlib
-        freetype
-        gtk3
-        libxml2
-        dbus
-        xcb-util-cursor
-        alsa-lib
-        libpulseaudio
-        pango
-        atk
-        cairo
-        gdk-pixbuf
-        glib
-        udev
-        libva
-        mesa
-        libnotify
-        cups
-        pciutils
-        ffmpeg
-        libglvnd
-        pipewire
-        speechd
-      ]
-      ++ (with pkgs.xorg; [
-        libxcb
-        libX11
-        libXcursor
-        libXrandr
-        libXi
-        libXext
-        libXcomposite
-        libXdamage
-        libXfixes
-        libXScrnSaver
-      ]);
+      mkZen = { }:
+        let downloadData = downloadUrl;
+        in pkgs.stdenv.mkDerivation {
+          inherit version;
+          pname = "zen-browser";
 
-    mkZen = {variant}: let
-      downloadData = downloadUrl."${variant}";
-    in
-      pkgs.stdenv.mkDerivation {
-        inherit version;
-        pname = "zen-browser";
+          src = builtins.fetchTarball {
+            url = downloadData.url;
+            sha256 = downloadData.sha256;
+          };
 
-        src = builtins.fetchTarball {
-          url = downloadData.url;
-          sha256 = downloadData.sha256;
+          desktopSrc = ./.;
+
+          phases = [ "installPhase" "fixupPhase" ];
+
+          nativeBuildInputs =
+            [ pkgs.makeWrapper pkgs.copyDesktopItems pkgs.wrapGAppsHook ];
+
+          installPhase = ''
+            mkdir -p $out/{bin,opt/zen} && cp -r $src/* $out/opt/zen
+            ln -s $out/opt/zen/zen $out/bin/zen
+
+            install -D $desktopSrc/zen.desktop $out/share/applications/zen.desktop
+
+            install -D $src/browser/chrome/icons/default/default16.png $out/share/icons/hicolor/16x16/apps/zen.png
+            install -D $src/browser/chrome/icons/default/default32.png $out/share/icons/hicolor/32x32/apps/zen.png
+            install -D $src/browser/chrome/icons/default/default48.png $out/share/icons/hicolor/48x48/apps/zen.png
+            install -D $src/browser/chrome/icons/default/default64.png $out/share/icons/hicolor/64x64/apps/zen.png
+            install -D $src/browser/chrome/icons/default/default128.png $out/share/icons/hicolor/128x128/apps/zen.png
+          '';
+
+          fixupPhase = ''
+            chmod 755 $out/bin/zen $out/opt/zen/*
+
+            patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/opt/zen/zen
+            wrapProgram $out/opt/zen/zen --set LD_LIBRARY_PATH "${
+              pkgs.lib.makeLibraryPath runtimeLibs
+            }" \
+                                 --set MOZ_LEGACY_PROFILES 1 --set MOZ_ALLOW_DOWNGRADE 1 --set MOZ_APP_LAUNCHER zen --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
+
+            patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/opt/zen/zen-bin
+                 wrapProgram $out/opt/zen/zen-bin --set LD_LIBRARY_PATH "${
+                   pkgs.lib.makeLibraryPath runtimeLibs
+                 }" \
+                                 --set MOZ_LEGACY_PROFILES 1 --set MOZ_ALLOW_DOWNGRADE 1 --set MOZ_APP_LAUNCHER zen --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
+
+            patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/opt/zen/glxtest
+                 wrapProgram $out/opt/zen/glxtest --set LD_LIBRARY_PATH "${
+                   pkgs.lib.makeLibraryPath runtimeLibs
+                 }"
+
+            patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/opt/zen/updater
+                 wrapProgram $out/opt/zen/updater --set LD_LIBRARY_PATH "${
+                   pkgs.lib.makeLibraryPath runtimeLibs
+                 }"
+
+            patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/opt/zen/vaapitest
+                 wrapProgram $out/opt/zen/vaapitest --set LD_LIBRARY_PATH "${
+                   pkgs.lib.makeLibraryPath runtimeLibs
+                 }"
+          '';
+
+          meta.mainProgram = "zen";
         };
-
-        desktopSrc = ./.;
-
-        phases = ["installPhase" "fixupPhase"];
-
-        nativeBuildInputs = [pkgs.makeWrapper pkgs.copyDesktopItems pkgs.wrapGAppsHook];
-
-        installPhase = ''
-          mkdir -p $out/{bin,opt/zen} && cp -r $src/* $out/opt/zen
-          ln -s $out/opt/zen/zen $out/bin/zen
-
-          install -D $desktopSrc/zen.desktop $out/share/applications/zen.desktop
-
-          install -D $src/browser/chrome/icons/default/default16.png $out/share/icons/hicolor/16x16/apps/zen.png
-          install -D $src/browser/chrome/icons/default/default32.png $out/share/icons/hicolor/32x32/apps/zen.png
-          install -D $src/browser/chrome/icons/default/default48.png $out/share/icons/hicolor/48x48/apps/zen.png
-          install -D $src/browser/chrome/icons/default/default64.png $out/share/icons/hicolor/64x64/apps/zen.png
-          install -D $src/browser/chrome/icons/default/default128.png $out/share/icons/hicolor/128x128/apps/zen.png
-        '';
-
-        fixupPhase = ''
-          chmod 755 $out/bin/zen $out/opt/zen/*
-
-          patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/opt/zen/zen
-          wrapProgram $out/opt/zen/zen --set LD_LIBRARY_PATH "${pkgs.lib.makeLibraryPath runtimeLibs}" \
-                               --set MOZ_LEGACY_PROFILES 1 --set MOZ_ALLOW_DOWNGRADE 1 --set MOZ_APP_LAUNCHER zen --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
-
-          patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/opt/zen/zen-bin
-               wrapProgram $out/opt/zen/zen-bin --set LD_LIBRARY_PATH "${pkgs.lib.makeLibraryPath runtimeLibs}" \
-                               --set MOZ_LEGACY_PROFILES 1 --set MOZ_ALLOW_DOWNGRADE 1 --set MOZ_APP_LAUNCHER zen --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
-
-          patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/opt/zen/glxtest
-               wrapProgram $out/opt/zen/glxtest --set LD_LIBRARY_PATH "${pkgs.lib.makeLibraryPath runtimeLibs}"
-
-          patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/opt/zen/updater
-               wrapProgram $out/opt/zen/updater --set LD_LIBRARY_PATH "${pkgs.lib.makeLibraryPath runtimeLibs}"
-
-          patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/opt/zen/vaapitest
-               wrapProgram $out/opt/zen/vaapitest --set LD_LIBRARY_PATH "${pkgs.lib.makeLibraryPath runtimeLibs}"
-        '';
-
-        meta.mainProgram = "zen";
-      };
-  in {
-    packages."${system}" = {
-      generic = mkZen {variant = "generic";};
-      specific = mkZen {variant = "specific";};
-      default = self.packages."${system}".specific;
-    };
-  };
+    in { packages."${system}" = mkZen { }; };
 }


### PR DESCRIPTION
In the latest release of **Zen Browser**, they removed the specific and generic builds and provide just a [generic build](https://github.com/zen-browser/desktop/wiki/Why-have-optimized-builds-been-removed%3F). 

Therefore I have removed everything regarding specific or generic and replaced it with the now updated download link from **Zen Browser**