### PR TITLE
fix: new naming scheme

### DIFF
--- a/.github/update.sh
+++ b/.github/update.sh
@@ -20,7 +20,7 @@ if [ "$twilight_version_name" = "" ]; then
     exit 1
 fi
 
-beta_tag=$(echo "$repo_tags" | jq -r '(map(select(.name | test("-b.")))) | first')
+beta_tag=$(echo "$repo_tags" | jq -r '(map(select(.name | test("[0-9]+\\.[0-9]+b$")))) | first')
 
 commit_beta_targets=""
 commit_beta_version=""

--- a/sources.json
+++ b/sources.json
@@ -1,16 +1,16 @@
 {
   "beta": {
     "x86_64-linux": {
-      "version": "1.0.2-b.5",
-      "sha1": "20c16af6d399fc325572e9beb404c160a1130aa8",
-      "url": "https://github.com/zen-browser/desktop/releases/download/1.0.2-b.5/zen.linux-x86_64.tar.bz2",
-      "sha256": "sha256-sS9phyr97WawxB2AZAwcXkvO3xAmv8k4C8b8Qw364PY="
+      "version": "1.6b",
+      "sha1": "859ff6c0888566939f74e9c194b5d0bb3ad6adc6",
+      "url": "https://github.com/zen-browser/desktop/releases/download/1.6b/zen.linux-x86_64.tar.bz2",
+      "sha256": "sha256-7Z7PZMTmPhB4Sx9+YXpWTkhcBsblzkgWyIJvNTSTNSU="
     },
     "aarch64-linux": {
-      "version": "1.0.2-b.5",
-      "sha1": "20c16af6d399fc325572e9beb404c160a1130aa8",
-      "url": "https://github.com/zen-browser/desktop/releases/download/1.0.2-b.5/zen.linux-aarch64.tar.bz2",
-      "sha256": "sha256-nuGSRzwBloFwgNCIbc5xv3vGkiHQxzOQr4FUX4Cip7Y="
+      "version": "1.6b",
+      "sha1": "859ff6c0888566939f74e9c194b5d0bb3ad6adc6",
+      "url": "https://github.com/zen-browser/desktop/releases/download/1.6b/zen.linux-aarch64.tar.bz2",
+      "sha256": "sha256-UD6pJnGr5MtSk62VOOwbCh62MFmS0DJOUshZM0ZH64s="
     }
   },
   "twilight": {


### PR DESCRIPTION
Hey,

Thanks for your flake :)
It sounds like the naming scheme changed for Zen's beta releases.
Here is a quick PR matching the new 1.6b release.

Wish you a nice day!