### PR TITLE
Fix tar.bz2 -> tar.xz and migrate from magic-nix-cache to flakehub-cache

### DIFF
--- a/.github/update.sh
+++ b/.github/update.sh
@@ -50,7 +50,7 @@ try_to_update() {
         fi
 
         version=$(echo "$target_tag_meta" | jq -r '.name')
-        download_url="https://github.com/zen-browser/desktop/releases/download/$version/zen.linux-$arch.tar.bz2"
+        download_url="https://github.com/zen-browser/desktop/releases/download/$version/zen.linux-$arch.tar.xz"
 
         prefetch_output=$(nix store prefetch-file --unpack --hash-type sha256 --json "$download_url")
         sha256=$(echo "$prefetch_output" | jq -r '.hash')

--- a/.github/workflows/zen-update.yml
+++ b/.github/workflows/zen-update.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Setup Nix Magic Cache
         if: steps.check.outputs.should_update == 'true'
-        uses: DeterminateSystems/magic-nix-cache-action@main
+        uses: DeterminateSystems/flakehub-cache-action@main
 
       - name: Update versions
         id: update


### PR DESCRIPTION
The update script now downloads the correct tar.xz package and the Github action uses flakehub-cache instead of magic-nix-cache 
```
Warning: Magic Nix Cache has been deprecated due to a change in the underlying GitHub APIs and will stop working on 1 February 2025.
```