### PR TITLE
Add missing libgbm and vulkan-loader dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,8 @@
           glib
           udev
           libva
+          libgbm
+          vulkan-loader
           mesa
           libnotify
           cups


### PR DESCRIPTION
see https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/applications/networking/browsers/firefox/wrapper.nix#L66

this fixes hardware video decoding 