### PR TITLE
Fix zen symlink: link to the binary that is going to be wrapped

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -84,7 +84,7 @@ in
       mkdir -p "$out/bin"
       ln -s "$prefix/lib/zen-bin-${variant.version}/zen" "$out/bin/${binaryName}"
       # ! twilight and beta could collide if both are installed
-      ln -s "$prefix/lib/zen-bin-${variant.version}/zen" "$out/bin/zen"
+      ln -s "$out/bin/${binaryName}" "$out/bin/zen"
 
       mkdir -p "$out/lib/zen-${variant.version}/distribution"
       ln -s ${policiesJson} "$out/lib/zen-${variant.version}/distribution/policies.json"


### PR DESCRIPTION
See https://github.com/0xc000022070/zen-browser-flake/issues/36#issuecomment-2777941082 