### PR TITLE
Force zen to set WM class to $MOZ_APP_LAUNCHER

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -77,6 +77,12 @@ in
     # Firefox uses "relrhack" to manually process relocations from a fixed offset
     patchelfFlags = ["--no-clobber-old-sections"];
 
+    preFixup = ''
+      gappsWrapperArgs+=(
+        --add-flags '--name "''${MOZ_APP_LAUNCHER:-${binaryName}}"'
+      )
+    '';
+
     installPhase = ''
       mkdir -p "$prefix/lib/zen-bin-${variant.version}"
       cp -r "$src"/* "$prefix/lib/zen-bin-${variant.version}"


### PR DESCRIPTION
Zen ignores the MOZ_APP_LAUNCHER variable which forces it to use the WM class specified by upstream 

We override the WM class in `pkgs.wrapFirefox` and set the class in `.desktop` file and expect the window to have this WM class

When launching zen from cli, it has its hardcoded WM class because it ignores MOZ_APP_LAUNCHER, and desktop environment panels cannot match the browser window to the corresponding `.desktop` item. This PR fixes the issue by forcing zen to use the WM class specified in `$MOZ_APP_LAUNCHER`. If `$MOZ_APP_LAUNCHER` is not specified, it defaults to `${binaryName}`