### PR TITLE
Allow policies.json management via unwrapped package override

### DIFF
--- a/hm-module.nix
+++ b/hm-module.nix
@@ -3,8 +3,8 @@
   self,
   name,
 }: {
-  pkgs,
   config,
+  pkgs,
   lib,
   ...
 }: let
@@ -38,9 +38,9 @@ in {
   config = lib.mkIf config.programs.zen-browser.enable {
     programs.zen-browser = {
       package = self.packages.${pkgs.stdenv.system}.${name};
-      policies = {
-        DisableAppUpdate = lib.mkDefault true;
-        DisableTelemetry = lib.mkDefault true;
+      policies = lib.mkDefault {
+        DisableAppUpdate = true;
+        DisableTelemetry = true;
       };
     };
   };

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -38,6 +38,7 @@ in {
   config = lib.mkIf config.programs.zen-browser.enable {
     programs.zen-browser = {
       package = self.packages.${pkgs.stdenv.system}.${name};
+      # This does not work, the package can't build using these policies
       policies = lib.mkDefault {
         DisableAppUpdate = true;
         DisableTelemetry = true;

--- a/package.nix
+++ b/package.nix
@@ -39,7 +39,7 @@
   };
 
   policies =
-    config.programs.zen-browser.policies
+    (config.firefox.policies or {})
     // {
       DisableAppUpdate = disableAppUpdate;
     };

--- a/package.nix
+++ b/package.nix
@@ -2,7 +2,7 @@
   name,
   variant,
   desktopFile,
-  disableAppUpdate ? true,
+  policies ? {},
   lib,
   stdenv,
   config,
@@ -38,13 +38,11 @@
     aarch64-linux = "linux-aarch64";
   };
 
-  policies =
+  firefoxPolicies =
     (config.firefox.policies or {})
-    // {
-      DisableAppUpdate = disableAppUpdate;
-    };
+    // policies;
 
-  policiesJson = writeText "firefox-policies.json" (builtins.toJSON {inherit policies;});
+  policiesJson = writeText "firefox-policies.json" (builtins.toJSON {policies = firefoxPolicies;});
 
   pname = "zen-${name}-bin-unwrapped";
 in

--- a/package.nix
+++ b/package.nix
@@ -2,6 +2,7 @@
   name,
   variant,
   desktopFile,
+  disableAppUpdate ? true,
   lib,
   stdenv,
   config,
@@ -38,10 +39,10 @@
   };
 
   policies =
-    {
-      DisableAppUpdate = true;
-    }
-    // config.firefox.policies or {};
+    config.firefox.policies
+    // {
+      DisableAppUpdate = disableAppUpdate;
+    };
 
   policiesJson = writeText "firefox-policies.json" (builtins.toJSON {inherit policies;});
 

--- a/package.nix
+++ b/package.nix
@@ -39,7 +39,7 @@
   };
 
   policies =
-    config.programs.zen-browser.policies
+    config.zen-browser.policies
     // {
       DisableAppUpdate = disableAppUpdate;
     };

--- a/package.nix
+++ b/package.nix
@@ -39,7 +39,7 @@
   };
 
   policies =
-    config.zen-browser.policies
+    config.policies
     // {
       DisableAppUpdate = disableAppUpdate;
     };

--- a/package.nix
+++ b/package.nix
@@ -39,7 +39,7 @@
   };
 
   policies =
-    config.firefox.policies
+    config.programs.zen-browser.policies
     // {
       DisableAppUpdate = disableAppUpdate;
     };

--- a/package.nix
+++ b/package.nix
@@ -39,7 +39,7 @@
   };
 
   policies =
-    config.policies
+    config.firefox.policies
     // {
       DisableAppUpdate = disableAppUpdate;
     };


### PR DESCRIPTION
Now the package policies can be modified like in the following snippet:

```nix
  home.packages = [
    (
      inputs.zen-browser.packages.${system}.twilight-unwrapped.override {
        policies = {
          DisableAppUpdate = true;
          DisableTelemetry = true;
        };
      }
    )
  ];
```

Solves: https://github.com/0xc000022070/zen-browser-flake/issues/48
Workaround for: https://github.com/0xc000022070/zen-browser-flake/issues/42