### PR TITLE
Fix policies handling

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -14,23 +14,15 @@ let
     pkgs.callPackage ./package.nix {
       inherit name desktopFile variant;
     };
-
-  mkZenWrapped =
-    pkgs: name: system: entry:
-    pkgs.wrapFirefox entry {
-      icon = "zen-${name}";
-      wmClass = "zen-${name}";
-      hasMozSystemDirPatch = false;
-    };
 in
 rec {
   beta-unwrapped = mkZen pkgs "beta" system "beta";
   twilight-unwrapped = mkZen pkgs "twilight" system "twilight";
   twilight-official-unwrapped = mkZen pkgs "twilight" system "twilight-official";
 
-  beta = mkZenWrapped pkgs "beta" system beta-unwrapped;
-  twilight = mkZenWrapped pkgs "twilight" system twilight-unwrapped;
-  twilight-official = mkZenWrapped pkgs "twilight" system twilight-official-unwrapped;
+  beta = pkgs.wrapFirefox beta-unwrapped;
+  twilight = pkgs.wrapFirefox twilight-unwrapped;
+  twilight-official = pkgs.wrapFirefox twilight-official-unwrapped;
 
   default = beta;
 }

--- a/default.nix
+++ b/default.nix
@@ -1,28 +1,23 @@
 {
-  pkgs ? import <nixpkgs> { },
+  pkgs ? import <nixpkgs> {},
   system ? pkgs.stdenv.hostPlatform.system,
-}:
+}: let
+  mkZen = pkgs: name: system: entry: let
+    variant = (builtins.fromJSON (builtins.readFile ./sources.json)).${entry}.${system};
 
-let
-  mkZen =
-    pkgs: name: system: entry:
-    let
-      variant = (builtins.fromJSON (builtins.readFile ./sources.json)).${entry}.${system};
-
-      desktopFile = "zen-${name}.desktop";
-    in
+    desktopFile = "zen-${name}.desktop";
+  in
     pkgs.callPackage ./package.nix {
       inherit name desktopFile variant;
     };
-in
-rec {
+in rec {
   beta-unwrapped = mkZen pkgs "beta" system "beta";
   twilight-unwrapped = mkZen pkgs "twilight" system "twilight";
   twilight-official-unwrapped = mkZen pkgs "twilight" system "twilight-official";
 
-  beta = pkgs.wrapFirefox beta-unwrapped { };
-  twilight = pkgs.wrapFirefox twilight-unwrapped { };
-  twilight-official = pkgs.wrapFirefox twilight-official-unwrapped { };
+  beta = pkgs.wrapFirefox beta-unwrapped {};
+  twilight = pkgs.wrapFirefox twilight-unwrapped {};
+  twilight-official = pkgs.wrapFirefox twilight-official-unwrapped {};
 
   default = beta;
 }

--- a/default.nix
+++ b/default.nix
@@ -20,9 +20,9 @@ rec {
   twilight-unwrapped = mkZen pkgs "twilight" system "twilight";
   twilight-official-unwrapped = mkZen pkgs "twilight" system "twilight-official";
 
-  beta = pkgs.wrapFirefox beta-unwrapped;
-  twilight = pkgs.wrapFirefox twilight-unwrapped;
-  twilight-official = pkgs.wrapFirefox twilight-official-unwrapped;
+  beta = pkgs.wrapFirefox beta-unwrapped { };
+  twilight = pkgs.wrapFirefox twilight-unwrapped { };
+  twilight-official = pkgs.wrapFirefox twilight-official-unwrapped { };
 
   default = beta;
 }

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,6 @@
     nixpkgs,
     home-manager,
   }: let
-
     supportedSystems = [
       "x86_64-linux"
       "aarch64-linux"
@@ -20,9 +19,10 @@
 
     forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
   in {
-    packages = forAllSystems (system: import ./default.nix {
-      pkgs = nixpkgs.legacyPackages.${system};
-    });
+    packages = forAllSystems (system:
+      import ./default.nix {
+        pkgs = nixpkgs.legacyPackages.${system};
+      });
 
     formatter = forAllSystems (
       system: let

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -37,7 +37,11 @@ in {
 
   config = lib.mkIf config.programs.zen-browser.enable {
     programs.zen-browser = {
-      package = self.packages.${pkgs.stdenv.system}.${name};
+      package = pkgs.wrapFirefox (self.packages.${pkgs.stdenv.system}."${name}-unwrapped".override {
+        # Seems like zen uses relative (to the original binary) path to the policies.json file
+        # and ignores the overrides by pkgs.wrapFirefox
+        policies = config.programs.zen-browser.policies;
+      }) { };
       # This does not work, the package can't build using these policies
       policies = lib.mkDefault {
         DisableAppUpdate = true;

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -41,7 +41,7 @@ in {
         # Seems like zen uses relative (to the original binary) path to the policies.json file
         # and ignores the overrides by pkgs.wrapFirefox
         policies = config.programs.zen-browser.policies;
-      }) { };
+      }) {};
       # This does not work, the package can't build using these policies
       policies = lib.mkDefault {
         DisableAppUpdate = true;

--- a/package.nix
+++ b/package.nix
@@ -33,6 +33,8 @@
 }: let
   binaryName = "zen-${name}";
 
+  libName = "zen-bin-${variant.version}";
+
   mozillaPlatforms = {
     x86_64-linux = "linux-x86_64";
     aarch64-linux = "linux-aarch64";
@@ -83,18 +85,18 @@ in
     '';
 
     installPhase = ''
-      mkdir -p "$prefix/lib/zen-bin-${variant.version}"
-      cp -r "$src"/* "$prefix/lib/zen-bin-${variant.version}"
+      mkdir -p "$prefix/lib/${libName}"
+      cp -r "$src"/* "$prefix/lib/${libName}"
 
       mkdir -p "$out/bin"
-      ln -s "$prefix/lib/zen-bin-${variant.version}/zen" "$out/bin/${binaryName}"
+      ln -s "$prefix/lib/${libName}/zen" "$out/bin/${binaryName}"
       # ! twilight and beta could collide if both are installed
       ln -s "$out/bin/${binaryName}" "$out/bin/zen"
 
       install -D $desktopSrc/${desktopFile} $out/share/applications/${desktopFile}
 
-      mkdir -p "$out/lib/zen-${variant.version}/distribution"
-      ln -s ${policiesJson} "$out/lib/zen-${variant.version}/distribution/policies.json"
+      mkdir -p "$out/lib/${libName}/distribution"
+      ln -s ${policiesJson} "$out/lib/${libName}/distribution/policies.json"
 
       install -D $src/browser/chrome/icons/default/default16.png $out/share/icons/hicolor/16x16/apps/zen-${name}.png
       install -D $src/browser/chrome/icons/default/default32.png $out/share/icons/hicolor/32x32/apps/zen-${name}.png
@@ -104,8 +106,7 @@ in
     '';
 
     passthru = {
-      inherit applicationName binaryName;
-      libName = "zen-bin-${variant.version}";
+      inherit applicationName binaryName libName;
       ffmpegSupport = true;
       gssSupport = true;
       gtk3 = gtk3;


### PR DESCRIPTION
Fixes typo in libName for policies.json

Remove unneeded wrapFirefox arguments (the current defaults for wrapFirefox are good for us)

Override the policies.json for the unwrapped variant in hm module

This should fix https://github.com/0xc000022070/zen-browser-flake/issues/42 without weird workarounds 