### PR TITLE
feat(package): add libGL as a runtime dependency

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -14,6 +14,7 @@
   gtk3,
   libXtst,
   libva,
+  libGL,
   pciutils,
   pipewire,
   adwaita-icon-theme,
@@ -71,8 +72,10 @@ in
       curl
       libva.out
       pciutils
+      libGL
     ];
     appendRunpaths = [
+      "${libGL}/lib"
       "${pipewire}/lib"
     ];
     # Firefox uses "relrhack" to manually process relocations from a fixed offset


### PR DESCRIPTION
Add libGL to ensure proper runtime support for OpenGL. Without this dependency, the browser logs errors related to missing GL libraries at startup.