### PR TITLE
revert: 'fix(sources): use temporal zen browser artifacts as source for beta'

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -2,9 +2,6 @@
 
 This is a nix flake for the Zen browser.
 
-> [!IMPORTANT]
-> The official Zen Browser organization is temporarily down, meanwhile the beta version is using an alternative source
-
 ## Features
 
 - Linux support

--- a/sources.json
+++ b/sources.json
@@ -3,13 +3,13 @@
     "x86_64-linux": {
       "version": "1.13.2b",
       "sha1": "dcd032856bd089e033eafb779d3f1b8665551597",
-      "url": "https://github.com/zen-browser-auto/www-temp/releases/download/1.13.2b/zen.linux-x86_64.tar.xz",
+      "url": "https://github.com/zen-browser/desktop/releases/download/1.13.2b/zen.linux-x86_64.tar.xz",
       "sha256": "sha256-VMlvtmb1sJQeDkPjnUNEA0eR2arFZ8BMs8EkK/sfq0I="
     },
     "aarch64-linux": {
       "version": "1.13.2b",
       "sha1": "dcd032856bd089e033eafb779d3f1b8665551597",
-      "url": "https://github.com/zen-browser-auto/www-temp/releases/download/1.13.2b/zen.linux-aarch64.tar.xz",
+      "url": "https://github.com/zen-browser/desktop/releases/download/1.13.2b/zen.linux-aarch64.tar.xz",
       "sha256": "sha256-QUquTsdigDt8ZKzGUlykTl9E+cRP5IlvvbUnDUH8Fbw="
     }
   },


### PR DESCRIPTION
closes #70 