### PR TITLE
feat(package): add libva-vdpau-driver as runtime dependency

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -18,6 +18,7 @@
   pciutils,
   pipewire,
   adwaita-icon-theme,
+  libva-vdpau-driver,
   writeText,
   patchelfUnstable, # have to use patchelfUnstable to support --no-clobber-old-sections
   applicationName ?
@@ -73,6 +74,7 @@ in
       libva.out
       pciutils
       libGL
+      libva-vdpau-driver
     ];
     appendRunpaths = [
       "${libGL}/lib"


### PR DESCRIPTION
Might resolve this issue:
https://github.com/0xc000022070/zen-browser-flake/issues/68