### PR TITLE
Fix shell variable interpolation in app name flag

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -85,7 +85,7 @@ in
 
     preFixup = ''
       gappsWrapperArgs+=(
-        --add-flags '--name "''${MOZ_APP_LAUNCHER:-${binaryName}}"'
+        --add-flags "--name=''${MOZ_APP_LAUNCHER:-${binaryName}}"
       )
     '';
 


### PR DESCRIPTION
The previous format [`--name "''${MOZ_APP_LAUNCHER:-${binaryName}}"`](https://github.com/0xc000022070/zen-browser-flake/blob/ea8a9b6b32027a1eeba7fcef4a3368d7f867c110/package.nix#L88) was causing shell variables to be literally included in the app-id/class/name instead of being properly interpolated.

Before: app-id contained literal shell syntax: `"${MOZ_APP_LAUNCHER:-zen-beta}"`
After: app-id properly resolves to the actual value: `zen-beta`
