### PR TITLE
Add aarch64-darwin to supportedSystems, mark as broken on darwin.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
     supportedSystems = [
       "x86_64-linux"
       "aarch64-linux"
+      "aarch64-darwin"
     ];
 
     forAllSystems = nixpkgs.lib.genAttrs supportedSystems;

--- a/package.nix
+++ b/package.nix
@@ -123,6 +123,7 @@ in
       changelog = "https://github.com/zen-browser/desktop/releases";
       sourceProvenance = with lib.sourceTypes; [binaryNativeCode];
       platforms = builtins.attrNames mozillaPlatforms;
+      broken = stdenv.hostPlatform.isDarwin;
       hydraPlatforms = [];
       mainProgram = binaryName;
     };


### PR DESCRIPTION
Fixes #78 -- should let anyone who wants to override programs.zen-browser.package to null to use the module with nix-darwin/home-manager.