### PR TITLE
feat: add aarch64-darwin (macOS) support

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -18,6 +18,7 @@
   pciutils,
   pipewire,
   adwaita-icon-theme,
+  undmg,
   writeText,
   patchelfUnstable, # have to use patchelfUnstable to support --no-clobber-old-sections
   applicationName ?
@@ -39,6 +40,7 @@
   mozillaPlatforms = {
     x86_64-linux = "linux-x86_64";
     aarch64-linux = "linux-aarch64";
+    aarch64-darwin = "darwin-aarch64";
   };
 
   firefoxPolicies =
@@ -48,36 +50,83 @@
   policiesJson = writeText "firefox-policies.json" (builtins.toJSON {policies = firefoxPolicies;});
 
   pname = "zen-${name}-bin-unwrapped";
+
+  installDarwin = ''
+    mkdir -p "$out/Applications" "$out/bin"
+    cp -r *.app "$out/Applications/${applicationName}.app"
+    ln -s zen "$out/Applications/${applicationName}.app/Contents/MacOS/${binaryName}"
+
+    cat > "$out/bin/${binaryName}" << EOF
+#!/bin/bash
+exec /usr/bin/open -na "$out/Applications/${applicationName}.app" --args "\$@"
+EOF
+
+    chmod +x "$out/bin/${binaryName}"
+    ln -s "$out/bin/${binaryName}" "$out/bin/zen"
+  '';
+
+  installLinux = ''
+    # Linux tarball installation
+    mkdir -p "$prefix/lib/${libName}"
+    cp -r "$src"/* "$prefix/lib/${libName}"
+
+    mkdir -p "$out/bin"
+    ln -s "$prefix/lib/${libName}/zen" "$out/bin/${binaryName}"
+    ln -s "$out/bin/${binaryName}" "$out/bin/zen"
+
+    install -D $desktopSrc/${desktopFile} $out/share/applications/${desktopFile}
+
+    mkdir -p "$out/lib/${libName}/distribution"
+    ln -s ${policiesJson} "$out/lib/${libName}/distribution/policies.json"
+
+    install -D $src/browser/chrome/icons/default/default16.png $out/share/icons/hicolor/16x16/apps/zen-${name}.png
+    install -D $src/browser/chrome/icons/default/default32.png $out/share/icons/hicolor/32x32/apps/zen-${name}.png
+    install -D $src/browser/chrome/icons/default/default48.png $out/share/icons/hicolor/48x48/apps/zen-${name}.png
+    install -D $src/browser/chrome/icons/default/default64.png $out/share/icons/hicolor/64x64/apps/zen-${name}.png
+    install -D $src/browser/chrome/icons/default/default128.png $out/share/icons/hicolor/128x128/apps/zen-${name}.png
+  '';
+
 in
   stdenv.mkDerivation {
     inherit pname;
     inherit (variant) version;
 
-    src = builtins.fetchTarball {inherit (variant) url sha256;};
+    src = if stdenv.hostPlatform.isDarwin
+      then builtins.fetchurl { inherit (variant) url sha256; }
+      else builtins.fetchTarball { inherit (variant) url sha256; };
+
+    sourceRoot = lib.optionalString stdenv.hostPlatform.isDarwin ".";
+
     desktopSrc = ./assets/desktop;
 
-    nativeBuildInputs = [
+    nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
       wrapGAppsHook3
       autoPatchelfHook
       patchelfUnstable
+    ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      undmg
     ];
-    buildInputs = [
+
+    buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
       gtk3
       adwaita-icon-theme
       alsa-lib
       dbus-glib
       libXtst
     ];
-    runtimeDependencies = [
+
+    runtimeDependencies = lib.optionals stdenv.hostPlatform.isLinux [
       curl
       libva.out
       pciutils
       libGL
     ];
-    appendRunpaths = [
+
+    appendRunpaths = lib.optionals stdenv.hostPlatform.isLinux [
       "${libGL}/lib"
       "${pipewire}/lib"
     ];
+
     # Firefox uses "relrhack" to manually process relocations from a fixed offset
     patchelfFlags = ["--no-clobber-old-sections"];
 
@@ -87,26 +136,9 @@ in
       )
     '';
 
-    installPhase = ''
-      mkdir -p "$prefix/lib/${libName}"
-      cp -r "$src"/* "$prefix/lib/${libName}"
-
-      mkdir -p "$out/bin"
-      ln -s "$prefix/lib/${libName}/zen" "$out/bin/${binaryName}"
-      # ! twilight and beta could collide if both are installed
-      ln -s "$out/bin/${binaryName}" "$out/bin/zen"
-
-      install -D $desktopSrc/${desktopFile} $out/share/applications/${desktopFile}
-
-      mkdir -p "$out/lib/${libName}/distribution"
-      ln -s ${policiesJson} "$out/lib/${libName}/distribution/policies.json"
-
-      install -D $src/browser/chrome/icons/default/default16.png $out/share/icons/hicolor/16x16/apps/zen-${name}.png
-      install -D $src/browser/chrome/icons/default/default32.png $out/share/icons/hicolor/32x32/apps/zen-${name}.png
-      install -D $src/browser/chrome/icons/default/default48.png $out/share/icons/hicolor/48x48/apps/zen-${name}.png
-      install -D $src/browser/chrome/icons/default/default64.png $out/share/icons/hicolor/64x64/apps/zen-${name}.png
-      install -D $src/browser/chrome/icons/default/default128.png $out/share/icons/hicolor/128x128/apps/zen-${name}.png
-    '';
+    installPhase = if stdenv.hostPlatform.isDarwin
+      then installDarwin
+      else installLinux;
 
     passthru = {
       inherit applicationName binaryName libName;
@@ -123,7 +155,6 @@ in
       changelog = "https://github.com/zen-browser/desktop/releases";
       sourceProvenance = with lib.sourceTypes; [binaryNativeCode];
       platforms = builtins.attrNames mozillaPlatforms;
-      broken = stdenv.hostPlatform.isDarwin;
       hydraPlatforms = [];
       mainProgram = binaryName;
     };

--- a/sources.json
+++ b/sources.json
@@ -11,6 +11,12 @@
       "sha1": "19fbad748ca8fc8b6673d4be17534fde8ad877ff",
       "url": "https://github.com/zen-browser/desktop/releases/download/1.14.7b/zen.linux-aarch64.tar.xz",
       "sha256": "sha256-Hc9dPGOv68+cRsdT5nOJbRmbTmZWXvPiIv7yFdJ9ngA="
+    },
+    "aarch64-darwin": {
+      "version": "1.14.7b",
+      "sha1": "19fbad748ca8fc8b6673d4be17534fde8ad877ff",
+      "url": "https://github.com/zen-browser/desktop/releases/download/1.14.7b/zen.macos-universal.dmg",
+      "sha256": "sha256-uu8BPOcYPZBrAzHrl0VriVeilgJ9y9AXT/Xaar6S/fc="
     }
   },
   "twilight": {

--- a/sources.json
+++ b/sources.json
@@ -31,6 +31,12 @@
       "sha1": "null",
       "url": "https://github.com/0xc000022070/zen-browser-flake/releases/download/1.15t-1753463200/zen.linux-aarch64.tar.xz",
       "sha256": "sha256-bttnCkWSmVVzxCucj5Jnkaer6ReGHr8KAUWKRekqSrg="
+    },
+    "aarch64-darwin": {
+      "version": "1.15t",
+      "sha1": "null",
+      "url": "https://github.com/zen-browser/desktop/releases/download/twilight/zen.macos-universal.dmg",
+      "sha256": "sha256-hFozFxbb/HWPjbhg6i2nV60ccpDC8lTONFT7e/+3Pfg="
     }
   },
   "twilight-official": {
@@ -45,6 +51,12 @@
       "sha1": "null",
       "url": "https://github.com/zen-browser/desktop/releases/download/twilight/zen.linux-aarch64.tar.xz",
       "sha256": "sha256-bttnCkWSmVVzxCucj5Jnkaer6ReGHr8KAUWKRekqSrg="
+    },
+    "aarch64-darwin": {
+      "version": "1.15t",
+      "sha1": "null",
+      "url": "https://github.com/zen-browser/desktop/releases/download/twilight/zen.macos-universal.dmg",
+      "sha256": "sha256-hFozFxbb/HWPjbhg6i2nV60ccpDC8lTONFT7e/+3Pfg="
     }
   },
   "twilight_metadata": {


### PR DESCRIPTION
## Description

This PR adds `aarch64-darwin` (macOS) support

I added conditional logic in both the `update.sh` script and `package.nix` to handle platform differences between Linux and Darwin

The script now properly handles macOS `DMG` files and updates all architectures in `sources.json`. I ran the `update.sh` script locally - beta updates work fine, but twilight updates need CI environment to function properly

Note: I'm new to `Nix`, so please let me know if anything needs changes

## How to test

`nix run .#packages.aarch64-darwin.default`