### PR TITLE
fix(hm-modules,spaces): run spaces script just on settings change

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -7,7 +7,7 @@ This is a nix flake for the Zen browser.
 - Linux and MacOS support
 - Available for _x86_64_ and _aarch64_
 - Support for _twilight_ and _beta_
-- Policies can be modified via Home Manager and unwrapped package override
+- [Policies can be modified via Home Manager and unwrapped package override](#policies)
 - Fast & Automatic updates via GitHub Actions
 - Browser update checks are disabled by default
 - The default twilight version is reliable and reproducible
@@ -123,94 +123,96 @@ experiment with other program options and help with further documentation.
   }
   ```
 
+### Policies
+
 - `policies` (attrsOf anything): You can also modify the **extensions** and **preferences** from here.
 
-  **Some common policies:**
+#### Some common policies
 
-  ```nix
-  {
-    programs.zen-browser.policies = {
-      AutofillAddressEnabled = true;
-      AutofillCreditCardEnabled = false;
-      DisableAppUpdate = true;
-      DisableFeedbackCommands = true;
-      DisableFirefoxStudies = true;
-      DisablePocket = true;
-      DisableTelemetry = true;
-      DontCheckDefaultBrowser = true;
-      NoDefaultBookmarks = true;
-      OfferToSaveLogins = false;
-      EnableTrackingProtection = {
-        Value = true;
-        Locked = true;
-        Cryptomining = true;
-        Fingerprinting = true;
-      };
+```nix
+{
+  programs.zen-browser.policies = {
+    AutofillAddressEnabled = true;
+    AutofillCreditCardEnabled = false;
+    DisableAppUpdate = true;
+    DisableFeedbackCommands = true;
+    DisableFirefoxStudies = true;
+    DisablePocket = true;
+    DisableTelemetry = true;
+    DontCheckDefaultBrowser = true;
+    NoDefaultBookmarks = true;
+    OfferToSaveLogins = false;
+    EnableTrackingProtection = {
+      Value = true;
+      Locked = true;
+      Cryptomining = true;
+      Fingerprinting = true;
     };
-  }
-  ```
+  };
+}
+```
 
-  For more policies [read this](https://mozilla.github.io/policy-templates/).
+For more policies [read this](https://mozilla.github.io/policy-templates/).
 
-  **Preferences:**
+#### Preferences
 
-  ```nix
-  {
-    programs.zen-browser.policies = let
-      mkLockedAttrs = builtins.mapAttrs (_: value: {
-        Value = value;
-        Status = "locked";
-      });
-    in {
-      Preferences = mkLockedAttrs {
-        "browser.tabs.warnOnClose" = false;
-        # and so on...
-      };
+```nix
+{
+  programs.zen-browser.policies = let
+    mkLockedAttrs = builtins.mapAttrs (_: value: {
+      Value = value;
+      Status = "locked";
+    });
+  in {
+    Preferences = mkLockedAttrs {
+      "browser.tabs.warnOnClose" = false;
+      # and so on...
     };
-  }
-  ```
+  };
+}
+```
 
-  **Zen-specific preferences:**
+##### Zen-specific preferences
 
-  Check [this comment](https://github.com/0xc000022070/zen-browser-flake/issues/59#issuecomment-2964607780).
+Check [this comment](https://github.com/0xc000022070/zen-browser-flake/issues/59#issuecomment-2964607780).
 
-  **Extensions:**
+#### Extensions
 
-  ```nix
-  {
-    programs.zen-browser.policies = let
-      mkExtensionSettings = builtins.mapAttrs (_: pluginId: {
-        install_url = "https://addons.mozilla.org/firefox/downloads/latest/${pluginId}/latest.xpi";
-        installation_mode = "force_installed";
-      });
-    in {
-      ExtensionSettings = mkExtensionSettings {
-        "wappalyzer@crunchlabz.com" = "wappalyzer";
-        "{85860b32-02a8-431a-b2b1-40fbd64c9c69}" = "github-file-icons";
-      };
+```nix
+{
+  programs.zen-browser.policies = let
+    mkExtensionSettings = builtins.mapAttrs (_: pluginId: {
+      install_url = "https://addons.mozilla.org/firefox/downloads/latest/${pluginId}/latest.xpi";
+      installation_mode = "force_installed";
+    });
+  in {
+    ExtensionSettings = mkExtensionSettings {
+      "wappalyzer@crunchlabz.com" = "wappalyzer";
+      "{85860b32-02a8-431a-b2b1-40fbd64c9c69}" = "github-file-icons";
     };
-  }
-  ```
+  };
+}
+```
 
-  To setup your own extensions you should:
+To setup your own extensions you should:
 
-   1. [Go to Add-ons for Firefox](https://addons.mozilla.org/en-US/firefox/).
-   2. Go to the page of the extension that you want to declare.
-   3. Go to "_See all versions_".
-   4. Copy the link from any button to "Download file".
-   5. Exec **wget** with the output of this command:
+ 1. [Go to Add-ons for Firefox](https://addons.mozilla.org/en-US/firefox/).
+ 2. Go to the page of the extension that you want to declare.
+ 3. Go to "_See all versions_".
+ 4. Copy the link from any button to "Download file".
+ 5. Exec **wget** with the output of this command:
 
-     ```bash
-     echo "<paste-the-link-here>" \
-      | sed -E 's|https://addons.mozilla.org/firefox/downloads/file/[0-9]+/([^/]+)-[^/]+\.xpi|\1|' \
-      | tr '_' '-' \
-      | awk '{print "https://addons.mozilla.org/firefox/downloads/latest/" $1 "/latest.xpi"}'
-     ```
+   ```bash
+   echo "<paste-the-link-here>" \
+    | sed -E 's|https://addons.mozilla.org/firefox/downloads/file/[0-9]+/([^/]+)-[^/]+\.xpi|\1|' \
+    | tr '_' '-' \
+    | awk '{print "https://addons.mozilla.org/firefox/downloads/latest/" $1 "/latest.xpi"}'
+   ```
 
-   6. Run `unzip -*.xpi -d my-extension && cd my-extension`.
-   7. Run `cat manifest.json | jq -r '.browser_specific_settings.gecko.id'` and use the result
-   for the _entry key_.
-   8. Don't forget to add the `install_url` and set `installation_mode` to `force_installed`.
+ 6. Run `unzip -*.xpi -d my-extension && cd my-extension`.
+ 7. Run `cat manifest.json | jq -r '.browser_specific_settings.gecko.id'` and use the result
+ for the _entry key_.
+ 8. Don't forget to add the `install_url` and set `installation_mode` to `force_installed`.
 
 ## 1Password
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -11,6 +11,7 @@ This is a nix flake for the Zen browser.
 - Fast & Automatic updates via GitHub Actions
 - Browser update checks are disabled by default
 - The default twilight version is reliable and reproducible
+- [Declarative \[Work\]Spaces (including themes, icons, containers)](#spaces)
 
 ## Installation
 
@@ -213,6 +214,87 @@ To setup your own extensions you should:
  7. Run `cat manifest.json | jq -r '.browser_specific_settings.gecko.id'` and use the result
  for the _entry key_.
  8. Don't forget to add the `install_url` and set `installation_mode` to `force_installed`.
+
+### Spaces
+
+> [!WARNING]
+> Spaces declaration may change your rebuild experience with Home Manager. Due to limitations
+> on how Zen handles spaces, the updating of them is done via a activation script on your
+> `home-manager-<user>.service`. This may cause the service to fail, to prevent this,
+> it is recommended to close your Zen browser instance before rebuilding.
+
+- `profiles.*.spaces` (attrsOf submodule): Declare profile's \[work\]spaces.
+  - `name` (string) Name of space, defaults to submodule/attribute name.
+  - `id` (string) **Required.** UUID v4 of space. **Changing this after a rebuild will re-create the space as 
+    a new one,** losing opened tabs, groups, etc. If `spacesForce` is true, the space with the previous UUID will be deleted.
+  - `position` (unsigned integer) Position/order of space in the left bar.
+  - `icon` (null or (string or path)) Emoji, URI or file path for icon to be used as space icon.
+  - `container` (null or unsigned integer) Container ID to be used as default in space.
+  - `theme.type` (nullOr string) Type of theme, defaults to "gradient".
+  - `theme.color` (listOf submodule) List of JSON colors to be used as theme:
+    - `red` (integer between 0 and 255) Red value of color (first value of "c" array in JSON object).
+    - `green` (integer between 0 and 255) Green value of color (second value of "c" array in JSON object).
+    - `blue` (integer between 0 and 255) Blue value of color (third value of "c" array in JSON object).
+    - `custom` (boolean) Is custom color ("isCustom" in JSON object).
+    - `algorithm` (enum of "complementary", "floating" or "analogous") color algorithm (defaults to "floating").
+    - `lightness` (integer) Lightness of color.
+    - `position.x` (integer) X Position of color in gradient picker on Zen browser.
+    - `position.y` (integer) Y Position of color in gradient picker on Zen browser.
+    - `type` (enum of "undefined" or "explicit-lightness") Type of color (default to "undefined").
+  - `theme.opacity` (null or float) Opacity of theme (defaults to 0.5).
+  - `theme.rotation` (null or integer) Rotation of theme gradient (defaults to null).
+  - `theme.texture` (null or float) Amount of texture of theme (defaults to 0.0).
+- `profiles.*.spacesForce` (boolean) Whether to delete existing spaces not declared in the configuration.
+  Recommended to make spaces fully declarative (defaults to false).
+
+```nix
+{
+  programs.zen-browser = {
+    enable = true;
+    profiles."default" = {
+      containersForce = true;
+      containers = {
+        Personal = {
+          color = "purple";
+          icon = "fingerprint";
+          id = 1;
+        };
+        Work = {
+          color = "blue";
+          icon = "briefcase";
+          id = 2;
+        };
+        Shopping = {
+          color = "yellow";
+          icon = "dollarsign";
+          id = 3;
+        };
+      };
+      spacesForce = true;
+      spaces = let
+        containers = config.programs.zen-browser.profiles."default".containers;
+      in {
+        "Space" = {
+          id = "c6de089c-410d-4206-961d-ab11f988d40a";
+          position = 1000;
+        };
+        "Work" = {
+          id = "cdd10fab-4fc5-494b-9041-325e5759195b";
+          icon = "chrome://browser/skin/zen-icons/selectable/star-2.svg";
+          container = containers."Work".id;
+          position = 2000;
+        };
+        "Shopping" = {
+          id = "78aabdad-8aae-4fe0-8ff0-2a0c6c4ccc24";
+          icon = "💸";
+          container = containers."Shopping".id;
+          position = 3000;
+        };
+      };
+    };
+  };
+}
+```
 
 ## 1Password
 

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -67,7 +67,7 @@ in {
               options = {
                 spacesForce = mkOption {
                   type = bool;
-                  description = "Whether delete existing spaces not declared in the configuration.";
+                  description = "Whether to delete existing spaces not declared in the configuration.";
                   default = false;
                 };
                 spaces = mkOption {

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -29,11 +29,13 @@
   linuxConfigPath = ".zen";
   darwinConfigPath = "Library/Application Support/Zen";
 
-  configPath = "${config.home.homeDirectory}/${(
-    if pkgs.stdenv.isDarwin
-    then darwinConfigPath
-    else linuxConfigPath
-  )}";
+  configPath = "${config.home.homeDirectory}/${
+    (
+      if pkgs.stdenv.isDarwin
+      then darwinConfigPath
+      else linuxConfigPath
+    )
+  }";
 
   mkFirefoxModule = import "${home-manager.outPath}/modules/programs/firefox/mkFirefoxModule.nix";
 in {
@@ -59,113 +61,134 @@ in {
   options = setAttrByPath modulePath {
     profiles = mkOption {
       type = with types;
-        attrsOf (submodule ({...}: {
-          options = {
-            spacesForce = mkOption {
-              type = bool;
-              description = "Whether delete existing spaces not declared in the configuration.";
-              default = false;
-            };
-            spaces = mkOption {
-              type = attrsOf (submodule ({name, ...}: {
-                options = {
-                  name = mkOption {
-                    type = str;
-                    description = "Name of the space.";
-                    default = name;
-                  };
-                  id = mkOption {
-                    type = str;
-                    description = "REQUIRED. Unique Version 4 UUID for space.";
-                  };
-                  position = mkOption {
-                    type = ints.unsigned;
-                    description = "Position of space in the left bar.";
-                    default = 1000;
-                  };
-                  icon = mkOption {
-                    type = nullOr (either str path);
-                    description = "Emoji or icon URI to be used as space icon.";
-                    apply = v:
-                      if isPath v
-                      then "file://${v}"
-                      else v;
-                    default = null;
-                  };
-                  container = mkOption {
-                    type = nullOr ints.unsigned;
-                    description = "Container ID to be used in space";
-                    default = null;
-                  };
-                  theme.type = mkOption {
-                    type = nullOr str;
-                    default = "gradient";
-                  };
-                  theme.colors = mkOption {
-                    type = nullOr (listOf (submodule ({...}: {
-                      options = {
-                        red = mkOption {
-                          type = int;
-                          default = 0;
-                        };
-                        green = mkOption {
-                          type = int;
-                          default = 0;
-                        };
-                        blue = mkOption {
-                          type = int;
-                          default = 0;
-                        };
-                        custom = mkOption {
-                          type = bool;
-                          default = false;
-                        };
-                        algorithm = mkOption {
-                          type = enum ["complementary" "floating" "analogous"];
-                          default = "floating";
-                        };
-                        primary = mkOption {
-                          type = bool;
-                          default = true;
-                        };
-                        lightness = mkOption {
-                          type = int;
-                          default = 0;
-                        };
-                        position.x = mkOption {
-                          type = int;
-                          default = 0;
-                        };
-                        position.y = mkOption {
-                          type = int;
-                          default = 0;
-                        };
-                        type = mkOption {
-                          type = enum ["undefined" "explicit-lightness"];
-                          default = "undefined";
-                        };
-                      };
-                    })));
-                    default = [];
-                  };
-                  theme.opacity = mkOption {
-                    type = nullOr float;
-                    default = 0.5;
-                  };
-                  theme.rotation = mkOption {
-                    type = nullOr int;
-                    default = null;
-                  };
-                  theme.texture = mkOption {
-                    type = nullOr float;
-                    default = 0.0;
-                  };
+        attrsOf (
+          submodule (
+            {...}: {
+              options = {
+                spacesForce = mkOption {
+                  type = bool;
+                  description = "Whether delete existing spaces not declared in the configuration.";
+                  default = false;
                 };
-              }));
-              default = {};
-            };
-          };
-        }));
+                spaces = mkOption {
+                  type = attrsOf (
+                    submodule (
+                      {name, ...}: {
+                        options = {
+                          name = mkOption {
+                            type = str;
+                            description = "Name of the space.";
+                            default = name;
+                          };
+                          id = mkOption {
+                            type = str;
+                            description = "REQUIRED. Unique Version 4 UUID for space.";
+                          };
+                          position = mkOption {
+                            type = ints.unsigned;
+                            description = "Position of space in the left bar.";
+                            default = 1000;
+                          };
+                          icon = mkOption {
+                            type = nullOr (either str path);
+                            description = "Emoji or icon URI to be used as space icon.";
+                            apply = v:
+                              if isPath v
+                              then "file://${v}"
+                              else v;
+                            default = null;
+                          };
+                          container = mkOption {
+                            type = nullOr ints.unsigned;
+                            description = "Container ID to be used in space";
+                            default = null;
+                          };
+                          theme.type = mkOption {
+                            type = nullOr str;
+                            default = "gradient";
+                          };
+                          theme.colors = mkOption {
+                            type = nullOr (
+                              listOf (
+                                submodule (
+                                  {...}: {
+                                    options = {
+                                      red = mkOption {
+                                        type = int;
+                                        default = 0;
+                                      };
+                                      green = mkOption {
+                                        type = int;
+                                        default = 0;
+                                      };
+                                      blue = mkOption {
+                                        type = int;
+                                        default = 0;
+                                      };
+                                      custom = mkOption {
+                                        type = bool;
+                                        default = false;
+                                      };
+                                      algorithm = mkOption {
+                                        type = enum [
+                                          "complementary"
+                                          "floating"
+                                          "analogous"
+                                        ];
+                                        default = "floating";
+                                      };
+                                      primary = mkOption {
+                                        type = bool;
+                                        default = true;
+                                      };
+                                      lightness = mkOption {
+                                        type = int;
+                                        default = 0;
+                                      };
+                                      position.x = mkOption {
+                                        type = int;
+                                        default = 0;
+                                      };
+                                      position.y = mkOption {
+                                        type = int;
+                                        default = 0;
+                                      };
+                                      type = mkOption {
+                                        type = enum [
+                                          "undefined"
+                                          "explicit-lightness"
+                                        ];
+                                        default = "undefined";
+                                      };
+                                    };
+                                  }
+                                )
+                              )
+                            );
+                            default = [];
+                          };
+                          theme.opacity = mkOption {
+                            type = nullOr float;
+                            default = 0.5;
+                          };
+                          theme.rotation = mkOption {
+                            type = nullOr int;
+                            default = null;
+                          };
+                          theme.texture = mkOption {
+                            type = nullOr float;
+                            default = 0.0;
+                          };
+                        };
+                      }
+                    )
+                  );
+                  default = {};
+                };
+              };
+            }
+          )
+        );
     };
   };
 

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -114,15 +114,15 @@ in {
                                   {...}: {
                                     options = {
                                       red = mkOption {
-                                        type = int;
+                                        type = ints.between 0 255;
                                         default = 0;
                                       };
                                       green = mkOption {
-                                        type = int;
+                                        type = ints.between 0 255;
                                         default = 0;
                                       };
                                       blue = mkOption {
-                                        type = int;
+                                        type = ints.between 0 255;
                                         default = 0;
                                       };
                                       custom = mkOption {


### PR DESCRIPTION
Continuation of PR #95 based of feedback provided on it, refactoring code to reduce the number of derivations being build and adding error handling to the bash script that creates spaces.

Changes compared to the original implementation:
- Reimplemented script via `home.file.*` and not via a systemd service, preventing the `places.sqlite` update script to being rerun on every home-manager rebuild.
- Run `nix fmt` on the hm-module.nix file, updating the formatting on how the options are defined.
- The SQL queries are now directly injected as strings in the Bash script, this reduced the amount of derivations being built by Nix to just one per-profile, since the implementation before created derivations for the `.sql` files.
- Better mimic the [behavior of Zen browser's `zen_workspaces` table creation](https://github.com/zen-browser/desktop/blob/6b2f1edf0dd92689142c00529454613671b6e313/src/zen/workspaces/ZenWorkspacesStorage.mjs#L25-L55), now the scripts creates theme columns just when they don't exist already. 
  - This fixes an apparent issue were opening Zen before the script ran caused the `zen_workspaces` to be created without the theme columns, in which the service would not be able to create via the "CREATE TABLE IF NOT EXISTS" query.
- Early exit if any of the steps in the process of creating and updating the tables fail via `|| exit 1` in every command on the Bash script.
- Added a check for if the error is related to the database being locked by another process, which 9 times out of 10 will be by having a Zen browser instance opened while the service tries to update the tables. If this check passes, the service echoes a error message guiding the user to close the instance and restart the service.

Example of `home-manager-<user>.service` error message due to database being locked:
```
$ systemctl status home-manager-user.service
× home-manager-user.service - Home Manager environment for user
     Loaded: loaded (/etc/systemd/system/home-manager-user.service; enabled; preset: ignored)
     Active: failed (Result: exit-code) since Thu 2025-08-21 11:01:45 -03; 4s ago
 Invocation: 9768457eceaa4805b86f1716e30dbf9d
    Process: 72154 ExecStart=/nix/store/d6mhq77jyaidz98k11wj0xragdkmw1a0-hm-setup-env /nix/store/93j0c3y1x74dlryj6kqi2h0sa00nk6pr-home-manager-generation (code=exited, status=1/FAILURE)
   Main PID: 72154 (code=exited, status=1/FAILURE)
         IP: 0B in, 0B out
         IO: 9.2M read, 0B written
   Mem peak: 12.4M
        CPU: 983ms

ago 21 11:01:34 battleship hm-activate-user[72154]: Activating flatpak-managed-install
ago 21 11:01:45 battleship hm-activate-user[72154]: Activating onFilesChange
ago 21 11:01:45 battleship hm-activate-user[73256]: Error: in prepare, database is locked (5)
ago 21 11:01:45 battleship hm-activate-user[73256]: zen-update-places: Failed to update "zen_workspaces" table.
ago 21 11:01:45 battleship hm-activate-user[73256]: zen-update-places: Failed to update "/home/user/.zen/default/places.sqlite" due to a Zen browser instance for profile "default" being opened, please close
ago 21 11:01:45 battleship hm-activate-user[73256]: zen-update-places: Zen browser and rebuild the home environment to rerun "home-manager-user.service" and update places.sqlite.
ago 21 11:01:45 battleship systemd[1]: home-manager-user.service: Main process exited, code=exited, status=1/FAILURE
ago 21 11:01:45 battleship systemd[1]: home-manager-user.service: Failed with result 'exit-code'.
ago 21 11:01:45 battleship systemd[1]: Failed to start Home Manager environment for guz.
ago 21 11:01:45 battleship systemd[1]: home-manager-user.service: Consumed 983ms CPU time, 12.4M memory peak, 9.2M read from disk.
```

> PS: Sorry for the multiple PRs, I was planning to add these fixes in the original #95 PR, but was unable to respond and update it before being merged. If anything wrong is find in this new PR, please let me know so I can fix it before being merged and not affect any end-user of the flake.