### PR TITLE
fix(package): fix startup wm class

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -192,6 +192,7 @@ in
     preFixup = ''
       gappsWrapperArgs+=(
         --add-flags "--name=''${MOZ_APP_LAUNCHER:-${binaryName}}"
+        --add-flags "--class=''${MOZ_APP_LAUNCHER:-${binaryName}}"
       )
     '';
 


### PR DESCRIPTION
--class argument should also be set to the correct class name