### PR TITLE
fix(hm-module): use heredoc for sqlite3 insert to preserve valid JSON

### DIFF
--- a/hm-module.nix
+++ b/hm-module.nix
@@ -251,8 +251,8 @@ in {
         placesFile = "${config.home.homeDirectory}/${configPath}/${profileName}/places.sqlite";
 
         insertSpaces = ''
-          # Reference: https://github.com/zen-browser/desktop/blob/4e2dfd8a138fd28767bb4799a3ca9d8aab80430e/src/zen/workspaces/ZenWorkspacesStorage.mjs#L25-L55
-          ${sqlite3} "${placesFile}" "${
+                    # Reference: https://github.com/zen-browser/desktop/blob/4e2dfd8a138fd28767bb4799a3ca9d8aab80430e/src/zen/workspaces/ZenWorkspacesStorage.mjs#L25-L55
+                    ${sqlite3} "${placesFile}" "${
             concatStringsSep " " [
               "CREATE TABLE IF NOT EXISTS zen_workspaces ("
               "id INTEGER PRIMARY KEY,"
@@ -267,25 +267,26 @@ in {
             ]
           }" || exit 1
 
-          columns=($(${sqlite3} "${placesFile}" "SELECT name FROM pragma_table_info('zen_workspaces');"))
-          if [[ ! "''${columns[@]}" =~ "theme_type" ]]; then
-            ${sqlite3} "${placesFile}" "ALTER TABLE zen_workspaces ADD COLUMN theme_type TEXT;" || exit 1
-          fi
-          if [[ ! "''${columns[@]}" =~ "theme_colors" ]]; then
-            ${sqlite3} "${placesFile}" "ALTER TABLE zen_workspaces ADD COLUMN theme_colors TEXT;" || exit 1
-          fi
-          if [[ ! "''${columns[@]}" =~ "theme_opacity" ]]; then
-            ${sqlite3} "${placesFile}" "ALTER TABLE zen_workspaces ADD COLUMN theme_opacity REAL;" || exit 1
-          fi
-          if [[ ! "''${columns[@]}" =~ "theme_rotation" ]]; then
-            ${sqlite3} "${placesFile}" "ALTER TABLE zen_workspaces ADD COLUMN theme_rotation INTEGER;" || exit 1
-          fi
-          if [[ ! "''${columns[@]}" =~ "theme_texture" ]]; then
-            ${sqlite3} "${placesFile}" "ALTER TABLE zen_workspaces ADD COLUMN theme_texture REAL;" || exit 1
-          fi
+                    columns=($(${sqlite3} "${placesFile}" "SELECT name FROM pragma_table_info('zen_workspaces');"))
+                    if [[ ! "''${columns[@]}" =~ "theme_type" ]]; then
+                      ${sqlite3} "${placesFile}" "ALTER TABLE zen_workspaces ADD COLUMN theme_type TEXT;" || exit 1
+                    fi
+                    if [[ ! "''${columns[@]}" =~ "theme_colors" ]]; then
+                      ${sqlite3} "${placesFile}" "ALTER TABLE zen_workspaces ADD COLUMN theme_colors TEXT;" || exit 1
+                    fi
+                    if [[ ! "''${columns[@]}" =~ "theme_opacity" ]]; then
+                      ${sqlite3} "${placesFile}" "ALTER TABLE zen_workspaces ADD COLUMN theme_opacity REAL;" || exit 1
+                    fi
+                    if [[ ! "''${columns[@]}" =~ "theme_rotation" ]]; then
+                      ${sqlite3} "${placesFile}" "ALTER TABLE zen_workspaces ADD COLUMN theme_rotation INTEGER;" || exit 1
+                    fi
+                    if [[ ! "''${columns[@]}" =~ "theme_texture" ]]; then
+                      ${sqlite3} "${placesFile}" "ALTER TABLE zen_workspaces ADD COLUMN theme_texture REAL;" || exit 1
+                    fi
 
-          # Reference: https://github.com/zen-browser/desktop/blob/4e2dfd8a138fd28767bb4799a3ca9d8aab80430e/src/zen/workspaces/ZenWorkspacesStorage.mjs#L141-L149
-          ${sqlite3} "${placesFile}" "${
+                    # Reference: https://github.com/zen-browser/desktop/blob/4e2dfd8a138fd28767bb4799a3ca9d8aab80430e/src/zen/workspaces/ZenWorkspacesStorage.mjs#L141-L149
+                    ${sqlite3} "${placesFile}" <<-'SQL' || exit 1
+          ${
             (concatStringsSep " " [
               "INSERT OR REPLACE INTO zen_workspaces ("
               "uuid,"
@@ -372,7 +373,8 @@ in {
               (map (row: concatStringsSep "," row))
               (concatMapStringsSep "," (row: "(${row})"))
             ])
-          }" || exit 1
+          }
+          SQL
         '';
 
         deleteSpaces = ''


### PR DESCRIPTION
This PR fixes a bug in the hm-module, when declaring `[work]spaces`, the `theme.colors` field was being stored in sqlite as **invalid JSON**.  
Because of that, Zen Browser would just show a blank window on startup (failed to parse workspaces).

Before the patch, running a quick check like:

```sql
sqlite3 ~/.zen/default/places.sqlite \
  'SELECT name, json_valid(theme_colors) AS ok, substr(theme_colors,1,160) FROM zen_workspaces;'
```
gave me results such as:
```
AI|0|[{algorithm:floating,c:[207,186,240],isCustom:false,isPrimary:true,...}]
Coding|0|[{algorithm:floating,c:[142,236,245],isCustom:false,isPrimary:true,...}]
```

Notice how json_valid(theme_colors) is 0, and the JSON lost its quotes (algorithm:floating instead of "algorithm":"floating"). That’s why Zen couldn’t load anything.

The issue was that the SQL was passed into sqlite3 as a quoted string, which messed up the output of Nix’s toJSON. The fix is actually simple: run the query through a heredoc so the JSON is passed along untouched. With:

```bash
${sqlite3} "${placesFile}" <<-'SQL' || exit 1
${
  (concatStringsSep " " [
    "INSERT OR REPLACE INTO zen_workspaces ("
    ...
  ])
}
SQL
```
the output becomes proper JSON again:
```sql
AI|1|[{"algorithm":"floating","c":[207,186,240],"isCustom":false,"isPrimary":true,...}]
Coding|1|[{"algorithm":"floating","c":[142,236,245],"isCustom":false,"isPrimary":true,...}]
```
Now json_valid(theme_colors) is 1 for all rows, Zen starts normally, and the workspace colors show up as expected. I used <<-'SQL' so it’s safe even if the file gets reformatted with alejandra.