### PR TITLE
Linux desktop icon for beta should be "zen-browser"

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -13,7 +13,9 @@ in rec {
   twilight-unwrapped = mkZen "twilight" "twilight";
   twilight-official-unwrapped = mkZen "twilight" "twilight-official";
 
-  beta = pkgs.wrapFirefox beta-unwrapped {};
+  beta = pkgs.wrapFirefox beta-unwrapped {
+    icon = "zen-browser";
+  };
   twilight = pkgs.wrapFirefox twilight-unwrapped {};
   twilight-official = pkgs.wrapFirefox twilight-official-unwrapped {};
 

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -207,10 +207,15 @@ in {
     programs.zen-browser = {
       package = lib.mkDefault (
         (pkgs.wrapFirefox (self.packages.${pkgs.stdenv.hostPlatform.system}."${name}-unwrapped".override {
-          # Seems like zen uses relative (to the original binary) path to the policies.json file
-          # and ignores the overrides by pkgs.wrapFirefox
-          policies = cfg.policies;
-        }) {}).override
+            # Seems like zen uses relative (to the original binary) path to the policies.json file
+            # and ignores the overrides by pkgs.wrapFirefox
+            policies = cfg.policies;
+          }) {
+            icon =
+              if name == "beta"
+              then "zen-browser"
+              else "zen-${name}";
+          }).override
         {
           extraPrefs = cfg.extraPrefs;
           extraPrefsFiles = cfg.extraPrefsFiles;

--- a/package.nix
+++ b/package.nix
@@ -55,6 +55,11 @@
 
   pname = "zen-${name}-bin-unwrapped";
 
+  desktopIconName =
+    if name == "beta"
+    then "zen-browser"
+    else binaryName;
+
   installDarwin = ''
     runHook preInstall
 
@@ -87,11 +92,11 @@
     mkdir -p "$out/lib/${libName}/distribution"
     ln -s ${policiesJson} "$out/lib/${libName}/distribution/policies.json"
 
-    install -D $src/browser/chrome/icons/default/default16.png $out/share/icons/hicolor/16x16/apps/zen-${name}.png
-    install -D $src/browser/chrome/icons/default/default32.png $out/share/icons/hicolor/32x32/apps/zen-${name}.png
-    install -D $src/browser/chrome/icons/default/default48.png $out/share/icons/hicolor/48x48/apps/zen-${name}.png
-    install -D $src/browser/chrome/icons/default/default64.png $out/share/icons/hicolor/64x64/apps/zen-${name}.png
-    install -D $src/browser/chrome/icons/default/default128.png $out/share/icons/hicolor/128x128/apps/zen-${name}.png
+    install -D $src/browser/chrome/icons/default/default16.png $out/share/icons/hicolor/16x16/apps/${desktopIconName}.png
+    install -D $src/browser/chrome/icons/default/default32.png $out/share/icons/hicolor/32x32/apps/${desktopIconName}.png
+    install -D $src/browser/chrome/icons/default/default48.png $out/share/icons/hicolor/48x48/apps/${desktopIconName}.png
+    install -D $src/browser/chrome/icons/default/default64.png $out/share/icons/hicolor/64x64/apps/${desktopIconName}.png
+    install -D $src/browser/chrome/icons/default/default128.png $out/share/icons/hicolor/128x128/apps/${desktopIconName}.png
 
     runHook postInstall
   '';
@@ -120,7 +125,7 @@ in
         name = binaryName;
         desktopName = "Zen Browser${lib.optionalString (name == "twilight") " Twilight"}";
         exec = "${binaryName} %u";
-        icon = binaryName;
+        icon = desktopIconName;
         type = "Application";
         mimeTypes = [
           "text/html"
@@ -193,7 +198,7 @@ in
 
     preFixup = ''
       gappsWrapperArgs+=(
-        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ ffmpeg ]}"
+        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ffmpeg]}"
         --add-flags "--name=''${MOZ_APP_LAUNCHER:-${binaryName}}"
         --add-flags "--class=''${MOZ_APP_LAUNCHER:-${binaryName}}"
       )


### PR DESCRIPTION
Closes https://github.com/0xc000022070/zen-browser-flake/issues/123.

The changes have been tested and appear compatible with both installation via package and hm-module.

For backward compatibility, **only** the _Icon_ entry in the desktop files generated by pkgs.wrapFirefox and the unwrapped package has been updated.

For reference:

<img width="792" height="418" alt="image" src="https://github.com/user-attachments/assets/c7b32685-9c37-46eb-9a5f-e7d05b83a64a" />

<img width="778" height="391" alt="image" src="https://github.com/user-attachments/assets/712f2f64-5e72-4e65-bb9f-e9e754b43f10" />
