### PR TITLE
Add instructions in the README about rycee's firefox addons

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -262,7 +262,8 @@ You can search for package names by going to
 >
 > If you are not using the
 > [fireox-addons](https://nur.nix-community.org/repos/rycee/) repo, your
-> configuration will still build with the extension, but it will not install.\
+> configuration will still build with the configuration, but the extension will
+> not install.\
 > Doing so through the repo will throw a build error warning you about the
 > package being unfree
 


### PR DESCRIPTION
Hello! I just found out about a much cleaner way to install extensions with the mkFirefoxModule using the firefox-addons NUR repo, and it works with zen too! I thought it would be nice to have this in the readme, my [configuration](www.github.com/Mrid22/nixos-config) using this method is on github if anyone wants to look at it.