### PR TITLE
fix: add quotes to path with spaces in onChange script

### DIFF
--- a/hm-module.nix
+++ b/hm-module.nix
@@ -627,7 +627,7 @@ in {
             ''
           );
           onChange = ''
-            ${config.home.homeDirectory}/${scriptFile}
+            "${config.home.homeDirectory}/${scriptFile}"
             if [[ "$?" -ne 0 ]]; then
               RED="\033[0;31m"
               NC="\033[0m"


### PR DESCRIPTION
The onChange script was failing on macOS when the path contains spaces (e.g., "Library/Application Support/Zen"). Without quotes, the shell interprets the path as multiple arguments, attempting to execute "/Users/<username>/Library/Application" as a command, which results in "Permission denied" error.

This fix adds double quotes around the script path to properly handle spaces in the path.

Fixes the error:
  activate: line 336: /Users/<username>/Library/Application: Permission denied