### PR TITLE
fix(macos): use profilePath for places.sqlite and script

### DIFF
--- a/hm-module.nix
+++ b/hm-module.nix
@@ -35,6 +35,13 @@
     else linuxConfigPath
   )}";
 
+  # Actual profile directory path where places.sqlite is located
+  profilePath = "${(
+    if pkgs.stdenv.isDarwin
+    then "${darwinConfigPath}/Profiles"
+    else linuxConfigPath
+  )}";
+
   mkFirefoxModule = import "${home-manager.outPath}/modules/programs/firefox/mkFirefoxModule.nix";
 in {
   imports = [
@@ -328,8 +335,8 @@ in {
     in (mapAttrs' (
       profileName: profile: let
         sqlite3 = getExe' pkgs.sqlite "sqlite3";
-        scriptFile = "${configPath}/${profileName}/places_update.sh";
-        placesFile = "${config.home.homeDirectory}/${configPath}/${profileName}/places.sqlite";
+        scriptFile = "${profilePath}/${profileName}/places_update.sh";
+        placesFile = "${config.home.homeDirectory}/${profilePath}/${profileName}/places.sqlite";
 
         insertSpaces = ''
                     # Reference: https://github.com/zen-browser/desktop/blob/4e2dfd8a138fd28767bb4799a3ca9d8aab80430e/src/zen/workspaces/ZenWorkspacesStorage.mjs#L25-L55


### PR DESCRIPTION
On macOS, Zen Browser stores profiles in:
Library/Application Support/Zen/Profiles/<profile>/

However, the module was using configPath for both scriptFile and placesFile, which would place them in the wrong directory.

This commit introduces profilePath variable that points to the actual profile directory location on macOS (configPath + /Profiles), ensuring both places_update.sh and places.sqlite are in the correct location alongside other profile files like containers.json.