### PR TITLE
fix: Add policies.json support for macOS (Darwin)

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -67,6 +67,10 @@
     cp -r *.app "$out/Applications/${applicationName}.app"
     ln -s zen "$out/Applications/${applicationName}.app/Contents/MacOS/${binaryName}"
 
+    # Install policies.json for macOS
+    mkdir -p "$out/Applications/${applicationName}.app/Contents/Resources/distribution"
+    ln -s ${policiesJson} "$out/Applications/${applicationName}.app/Contents/Resources/distribution/policies.json"
+
     cat > "$out/bin/${binaryName}" << EOF
     #!/bin/bash
     exec /usr/bin/open -na "$out/Applications/${applicationName}.app" --args "\$@"


### PR DESCRIPTION
Previously, policies.json was only installed for Linux builds, causing browser policies (including ExtensionSettings) to be ignored on macOS. This resulted in extensions not being automatically installed on macOS systems.

This fix adds the policies.json installation to the Darwin install phase, mirroring the Linux behavior and ensuring policy enforcement works correctly on macOS.

Fixes extension auto-installation and other policy-based features on macOS.