### PR TITLE
Revert "fix(package): ensure both bin symlinks point directly to the zen binary"

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -106,7 +106,7 @@
 
     mkdir -p "$out/bin"
     ln -s "$prefix/lib/${libName}/zen" "$out/bin/${binaryName}"
-    ln -s "$prefix/lib/${libName}/zen" "$out/bin/zen"
+    ln -s "$out/bin/${binaryName}" "$out/bin/zen"
 
     mkdir -p "$out/lib/${libName}/distribution"
     ln -s ${policiesJson} "$out/lib/${libName}/distribution/policies.json"


### PR DESCRIPTION
Reverts 0xc000022070/zen-browser-flake#155