### PR TITLE
revert: "chore(update): beta @ x86_64 && aarch64 to 1.17.6b"

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -1,22 +1,22 @@
 {
   "beta": {
     "x86_64-linux": {
-      "version": "1.17.6b",
-      "sha1": "a0f282a7598c2d5649646263675ee045461283bd",
-      "url": "https://github.com/zen-browser/desktop/releases/download/1.17.6b/zen.linux-x86_64.tar.xz",
-      "sha256": "sha256-8nkjVQeo/GEpkK/JZQHctzku/mAC7zwY/nXz1SmQw6U="
+      "version": "1.17.5b",
+      "sha1": "0d80532bf127cc1c0c890fc853afbd9c02c9b0c9",
+      "url": "https://github.com/zen-browser/desktop/releases/download/1.17.5b/zen.linux-x86_64.tar.xz",
+      "sha256": "sha256-AbRgWf3YZWIdF8gINP93BqC4FmxZP+T6cE2wL5+BkY8="
     },
     "aarch64-linux": {
-      "version": "1.17.6b",
-      "sha1": "a0f282a7598c2d5649646263675ee045461283bd",
-      "url": "https://github.com/zen-browser/desktop/releases/download/1.17.6b/zen.linux-aarch64.tar.xz",
-      "sha256": "sha256-XAAiTKkY10BxUkKjGMGnayPoMAfdkOQVWas8nBTgibk="
+      "version": "1.17.5b",
+      "sha1": "0d80532bf127cc1c0c890fc853afbd9c02c9b0c9",
+      "url": "https://github.com/zen-browser/desktop/releases/download/1.17.5b/zen.linux-aarch64.tar.xz",
+      "sha256": "sha256-fbX/wkQMA41mnyJx+80MV9xvfloxUmYIvgM0KrWOWCM="
     },
     "aarch64-darwin": {
-      "version": "1.17.6b",
-      "sha1": "a0f282a7598c2d5649646263675ee045461283bd",
-      "url": "https://github.com/zen-browser/desktop/releases/download/1.17.6b/zen.macos-universal.dmg",
-      "sha256": "sha256-g6yVVGGGyeMHywiEh2KFXQ6Zmvvqjdv1mc7zGhAFL3k="
+      "version": "1.17.5b",
+      "sha1": "0d80532bf127cc1c0c890fc853afbd9c02c9b0c9",
+      "url": "https://github.com/zen-browser/desktop/releases/download/1.17.5b/zen.macos-universal.dmg",
+      "sha256": "sha256-ovChi4lJRh3Gh8G/iy3Wkd1iZYzxzkCBfT0Hj/A7LFQ="
     }
   },
   "twilight": {


### PR DESCRIPTION
Closes https://github.com/0xc000022070/zen-browser-flake/issues/161.

This reverts commit 40598467cab52d10f5b8ab4a5126ac9503ea9383.