### PR TITLE
fix(darwin): skip stripping to preserve code signatures instead of ad…

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -71,12 +71,6 @@
     mkdir -p "$out/Applications/${applicationName}.app/Contents/Resources/distribution"
     ln -s ${policiesJson} "$out/Applications/${applicationName}.app/Contents/Resources/distribution/policies.json"
 
-    # Re-sign with correct identifier to maintain AdGuard compatibility
-    # AdGuard uses code signing identifier (not CFBundleIdentifier) to recognize apps
-    /usr/bin/codesign --force --deep --sign - \
-      --identifier "app.zen-browser.zen" \
-      "$out/Applications/${applicationName}.app"
-
     # Use symlink path to avoid installs.ini accumulation on Nix rebuilds
     # The symlink is created by home-manager and remains stable across rebuilds
     cat > "$out/bin/${binaryName}" << EOF
@@ -214,6 +208,12 @@ in
 
     # Firefox uses "relrhack" to manually process relocations from a fixed offset
     patchelfFlags = ["--no-clobber-old-sections"];
+
+    # Stripping invalidates macOS code signatures. We avoid strip-and-re-sign
+    # because /usr/bin/codesign is inaccessible in the Nix sandbox. This also
+    # preserves the original code signing identifier that tools like AdGuard
+    # use (not CFBundleIdentifier) to recognize apps.
+    dontStrip = stdenv.hostPlatform.isDarwin;
 
     preFixup = ''
       gappsWrapperArgs+=(


### PR DESCRIPTION
Thanks for maintaining this great project!

I've been using this flake on Linux for several months, and I'm glad to see it now supports Darwin. However, I encountered some installation issues on macOS and would like to propose a fix.

## Problem

#150 introduced ad-hoc re-signing with `/usr/bin/codesign` to maintain the code signing identifier `app.zen-browser.zen` for AdGuard compatibility. However, this approach fails when 
building in a Nix sandbox because `/usr/bin/codesign` is inaccessible.

## Solution

This PR removes the codesign call and instead sets `dontStrip = true` on Darwin. By preserving the original binaries from the upstream .dmg, the code signature remains intact without any re-signing.

## Why stripping breaks code signatures

When Nix strips the binaries, it invalidates the original code signature. The linker then automatically re-signs with an ad-hoc signature, but it uses a generic identifier "zen" instead of "app.zen-browser.zen". This breaks AdGuard's ability to recognize the app.


With `dontStrip = true`:

```
$ codesign -dv result/Applications/Zen\ Browser\ \(Beta\).app/
Executable=/nix/store/armdmnywn8ylysxqwcr9s5ss0ylmr5w1-zen-beta-1.17.15b/Applications/Zen Browser (Beta).app/Contents/MacOS/zen
Identifier=app.zen-browser.zen
Format=app bundle with Mach-O universal (x86_64 arm64)
CodeDirectory v=20500 size=927 flags=0x10000(runtime) hashes=18+7 location=embedded
Signature size=8973
Timestamp=Dec 21, 2025 at 1:30:32
Info.plist entries=26
TeamIdentifier=9V5K9TP787
Runtime Version=26.1.0
Sealed Resources version=2 rules=13 files=71
Internal requirements count=1 size=180
```

With `dontStrip = false` (default):

```
$ codesign -dv result/Applications/Zen\ Browser\ \(Beta\).app/
Executable=/nix/store/3q1qra41fg15v3la2598zawssy1allg0-zen-beta-1.17.15b/Applications/Zen Browser (Beta).app/Contents/MacOS/zen
Identifier=zen
Format=app bundle with Mach-O universal (x86_64 arm64)
CodeDirectory v=20400 size=680 flags=0x20002(adhoc,linker-signed) hashes=18+0 location=embedded
Signature=adhoc
Info.plist=not bound
TeamIdentifier=not set
Sealed Resources=none
Internal requirements=none
```

## Request for review

I haven't personally encountered the AdGuard recognition issue, and the current main branch doesn't build in my sandbox environment due to the codesign call. Because of this, I cannot verify whether this approach correctly preserves the behavior that #150 intended to provide.

@retX0, since you implemented the original codesign fix, could you please verify that AdGuard still correctly recognizes the app with this change?
