### PR TITLE
fix: use unwrapped package on macOS to resolve URL handling bugs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,16 +8,19 @@
     pkgs.callPackage ./package.nix {
       inherit name variant;
     };
+  
+  wrap = unwrapped: icon:
+    if pkgs.stdenv.isDarwin
+    then unwrapped
+    else pkgs.wrapFirefox unwrapped (if icon != null then {inherit icon;} else {});
 in rec {
   beta-unwrapped = mkZen "beta" "beta";
   twilight-unwrapped = mkZen "twilight" "twilight";
   twilight-official-unwrapped = mkZen "twilight" "twilight-official";
 
-  beta = pkgs.wrapFirefox beta-unwrapped {
-    icon = "zen-browser";
-  };
-  twilight = pkgs.wrapFirefox twilight-unwrapped {};
-  twilight-official = pkgs.wrapFirefox twilight-official-unwrapped {};
+  beta = wrap beta-unwrapped "zen-browser";
+  twilight = wrap twilight-unwrapped null;
+  twilight-official = wrap twilight-official-unwrapped null;
 
   default = beta;
 }

--- a/package.nix
+++ b/package.nix
@@ -36,6 +36,7 @@
       then " (Twilight)"
       else ""
     ),
+  ...
 }: let
   binaryName = "zen-${name}";
 


### PR DESCRIPTION
The `wrapFirefox` wrapper creates a shell script entry point. On macOS, this interferes with Launch Services' ability to deliver Apple Events (like URL open requests) to the actual application binary. As a result, clicking links or running `open <url>` would launch the browser but fail to open the requested URL.

This change switches macOS to use the unwrapped package directly, ensuring the native `.app` bundle structure is preserved. Preferences and policies are now injected directly into the package at build time (via `package.nix`) rather than relying on the wrapper.

On Linux, the wrapper is still used to handle environment variables and native messaging hosts. Configuration logic in `hm-module.nix` has been refactored to prevent redundant argument passing.