### PR TITLE
fix(macos): preserve code signature by removing wrapFirefox and using…

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -13,11 +13,11 @@ in rec {
   twilight-unwrapped = mkZen "twilight" "twilight";
   twilight-official-unwrapped = mkZen "twilight" "twilight-official";
 
-  beta = pkgs.wrapFirefox beta-unwrapped {
+  beta = if pkgs.stdenv.isDarwin then beta-unwrapped else pkgs.wrapFirefox beta-unwrapped {
     icon = "zen-browser";
   };
-  twilight = pkgs.wrapFirefox twilight-unwrapped {};
-  twilight-official = pkgs.wrapFirefox twilight-official-unwrapped {
+  twilight = if pkgs.stdenv.isDarwin then twilight-unwrapped else pkgs.wrapFirefox twilight-unwrapped {};
+  twilight-official = if pkgs.stdenv.isDarwin then twilight-official-unwrapped else pkgs.wrapFirefox twilight-official-unwrapped {
     icon = "zen-twilight";
   };
 


### PR DESCRIPTION
… defaults for policies

This commit addresses the macOS code signature issue by making the following changes:

**Changes:**
- Remove wrapFirefox on macOS to preserve the original app bundle and its code signature
- Use home-manager's targets.darwin.defaults to write policies to plist instead of policies.json
- Use unwrapped package directly on macOS (no wrapper script modifications inside .app)
- Set binaryName to "zen" on macOS to match the actual executable name
- Add ... to package.nix function parameters to accept arbitrary arguments from callPackage

**Benefits:**
- Preserves the original code signature from upstream Zen Browser
- Fixes issues with apps like AdGuard that check code signing identifiers
- Avoids regenerating install IDs on every rebuild
- Ensures proper URL handling and app recognition by macOS

Closes #193