### PR TITLE
README: add alternate way to quickly find ids for keyboard shortcuts

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -603,11 +603,13 @@ When you declare a shortcut override:
 
 ### Finding Shortcut IDs
 
-Find all shortcuts in `~/.zen/<profile>/zen-keyboard-shortcuts.json`. For example:
+Search for shortcut IDs and their actions in `~/.zen/<profile>/zen-keyboard-shortcuts.json`. For example:
 
 ```bash
-jq -c '.shortcuts[] | {id, key, keycode, action}' ~/.zen/default/zen-keyboard-shortcuts.json
+jq -c '.shortcuts[] | {id, key, keycode, action}' ~/.zen/default/zen-keyboard-shortcuts.json | fzf
 ```
+
+Alternatively, you could also go to the keyboard shorcuts page in settings, and then inspect the input field of the shortcut you want to change, in the inspect window look for "key={whatever}", the value of "key" is the id you should put in your configuration
 
 ### Notes on activation
 


### PR DESCRIPTION
I added a small note with an alternate way to find ID's for the shortcuts, where you can just inspect the input field for the action, and the id of it is written as key="id"