### PR TITLE
fix(hm-module): use correct app name for search hash when package is null

### DIFF
--- a/hm-module/default.nix
+++ b/hm-module/default.nix
@@ -32,7 +32,7 @@
     };
   };
 
-  applicationName = "Zen Browser";
+  applicationName = "Zen";
   linuxConfigPath = "${config.xdg.configHome}/zen";
   darwinConfigPath = "${config.home.homeDirectory}/Library/Application Support/Zen";
 


### PR DESCRIPTION
#### Issue

When `package = null;`, `mkFirefoxModule` falls back to `applicationName` when checking hashes to set the default search engine. `applicationName = "Zen Browser";` doesn't match the cask's application.ini, "Zen", causing Firefox's hash verification to (silently) fail. Search engine default settings won't apply-unsure about others.

#### Context

In my config, I have installed Twilight as a homebrew cask and some configuration settings were not applying, namely Kagi as a custom default search engine. The setting was overwritten between launches / switches.

mkFirefoxModule should be overriding applicationName in all cases except the `package = null;` case, meaning existing, working configs shouldn't be affected. See [here](https://github.com/nix-community/home-manager/blob/b3ccd4bb262f4e6d3248b46cede92b90c4a42094/modules/programs/firefox/profiles/search.nix#L173) for how the search setting handles it, and the below snippet for the mismatch:

```shellsession
$ grep '^Name=' "/Applications/Twilight.app/Contents/Resources/application.ini"
Name=Zen
```

#### Testing Done

 To test, I manually changed the setting to Google, closed Twilight, ran `$ sudo darwin-rebuild switch` with this PR pinned, and reopened Twilight to the correct setting. 
