### PR TITLE
Restore editedTitle functionality for pins

### DIFF
--- a/hm-module/places.nix
+++ b/hm-module/places.nix
@@ -337,6 +337,9 @@ in {
                         else "{${p.folderParentId}}"
                       else null;
                   }
+                  // optionalAttrs p.editedTitle {
+                    zenStaticLabel = p.title;
+                  }
                   // optionalAttrs (!isNull p.url) {
                     entries = [
                       {
@@ -457,7 +460,7 @@ in {
               . as $e |
               ($pins | map(select(.zenSyncId == $e.zenSyncId)) | .[0] // null) as $o |
               if $o != null then
-                $e * {pinned: $o.pinned, zenEssential: $o.zenEssential, zenWorkspace: $o.zenWorkspace, userContextId: $o.userContextId, index: $o.index, entries: $o.entries, groupId: $o.groupId}
+                $e * {pinned: $o.pinned, zenEssential: $o.zenEssential, zenWorkspace: $o.zenWorkspace, userContextId: $o.userContextId, index: $o.index, entries: $o.entries, groupId: $o.groupId, zenStaticLabel: $o.zenStaticLabel}
               else . end
             ] |
             .tabs += [$pins[] | select(.zenSyncId as $id | $etIds | index($id) | not)]


### PR DESCRIPTION
The editedTitle option was not being used. This PR restores the ability to set custom tab titles by adding zenStaticLabel attribute to pins JSON generation.
