### PR TITLE
Fix hash mismatch

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -25,13 +25,13 @@
         "version": "twilight-1",
         "sha1": "368cb06d774725cf2462d1b2e305575bc93eb7ff",
         "url": "https://github.com/zen-browser/desktop/releases/download/twilight-1/zen.linux-x86_64.tar.xz",
-        "sha256": "sha256-MQzJQlE7KX2q0Bda41uvxD1uzcDC4qVukDaXoTeiTlI="
+        "sha256": "sha256-3ia9fNT8pfmD+/5Bw2kApIv0VqetrGDAj64FnOZZ0a8="
       },
       "aarch64-linux": {
         "version": "twilight-1",
         "sha1": "368cb06d774725cf2462d1b2e305575bc93eb7ff",
         "url": "https://github.com/zen-browser/desktop/releases/download/twilight-1/zen.linux-aarch64.tar.xz",
-        "sha256": "sha256-5oIFYpQVIqsJt59Qqf+I4dv8rJqoZeXaajs9kdzNXSg="
+        "sha256": "sha256-sB6JF07+E0rCkmZENYEtZm4LHzpGaw/x06kTRFwQgYw="
       },
       "aarch64-darwin": {
         "version": "twilight-1",
@@ -45,13 +45,13 @@
         "version": "twilight-1",
         "sha1": "368cb06d774725cf2462d1b2e305575bc93eb7ff",
         "url": "https://github.com/zen-browser/desktop/releases/download/twilight-1/zen.linux-x86_64.tar.xz",
-        "sha256": "sha256-MQzJQlE7KX2q0Bda41uvxD1uzcDC4qVukDaXoTeiTlI="
+        "sha256": "sha256-3ia9fNT8pfmD+/5Bw2kApIv0VqetrGDAj64FnOZZ0a8="
       },
       "aarch64-linux": {
         "version": "twilight-1",
         "sha1": "368cb06d774725cf2462d1b2e305575bc93eb7ff",
         "url": "https://github.com/zen-browser/desktop/releases/download/twilight-1/zen.linux-aarch64.tar.xz",
-        "sha256": "sha256-5oIFYpQVIqsJt59Qqf+I4dv8rJqoZeXaajs9kdzNXSg="
+        "sha256": "sha256-sB6JF07+E0rCkmZENYEtZm4LHzpGaw/x06kTRFwQgYw="
       },
       "aarch64-darwin": {
         "version": "twilight-1",


### PR DESCRIPTION
Address issue #263 -- change the hash of both the twilight and twilight-official to match on both x86_64 and aarch64 platforms.