### PR TITLE
Properly specify lang tags

### DIFF
--- a/hm-module/mods.nix
+++ b/hm-module/mods.nix
@@ -60,7 +60,7 @@ in {
         profileName: profile: let
           themesFilePath = "${profilePath}/${profileName}/zen-themes.json";
 
-          updateModsScript = pkgs.writeShellScript "zen-mods-update-${profileName}" ''            # bash
+          updateModsScript = pkgs.writeShellScript "zen-mods-update-${profileName}" /* bash */ ''
                       THEMES_FILE="${themesFilePath}"
                       MODS="${lib.concatStringsSep " " profile.mods}"
                       BASE_DIR="${profilePath}/${profileName}"

--- a/hm-module/places.nix
+++ b/hm-module/places.nix
@@ -499,7 +499,7 @@ in {
             .groups = (.groups | sort_by(.index // 0))
           '';
 
-          updateScript = pkgs.writeShellScript "zen-sessions-update-${profileName}" ''            # bash
+          updateScript = pkgs.writeShellScript "zen-sessions-update-${profileName}" /* bash */ ''
             SESSIONS_FILE="${sessionsFile}"
             SESSIONS_TMP="$(mktemp)"
             SESSIONS_MODIFIED="$(mktemp)"
@@ -568,7 +568,7 @@ in {
             rm -f "$BACKUP_FILE"
           '';
         in
-          nameValuePair "zen-sessions-${profileName}" (lib.hm.dag.entryAfter ["writeBoundary"] ''            # bash
+          nameValuePair "zen-sessions-${profileName}" (lib.hm.dag.entryAfter ["writeBoundary"] /* bash */ ''
             ${updateScript}
             if [[ "$?" -eq 0 ]]; then
               $VERBOSE_ECHO "zen-sessions: Updated spaces/pins for profile '${profileName}'"

--- a/hm-module/sine.nix
+++ b/hm-module/sine.nix
@@ -104,7 +104,7 @@ in {
         profileName: profile: let
           modsFilePath = "${profilePath}/${profileName}/chrome/sine-mods/mods.json";
 
-          updateSineModsScript = pkgs.writeShellScript "zen-sine-mods-update-${profileName}" ''            # bash
+          updateSineModsScript = pkgs.writeShellScript "zen-sine-mods-update-${profileName}" /* bash */ ''
             MODS_FILE="${modsFilePath}"
             SINE_MODS="${lib.concatStringsSep " " profile.sine.mods}"
             BASE_DIR="${profilePath}/${profileName}"
@@ -271,7 +271,7 @@ in {
             fi
           '';
         in
-          nameValuePair "zen-sine-mods-${profileName}" (lib.hm.dag.entryAfter ["writeBoundary"] ''            # bash
+          nameValuePair "zen-sine-mods-${profileName}" (lib.hm.dag.entryAfter ["writeBoundary"] /* bash */ ''
             ${updateSineModsScript}
             if [[ "$?" -eq 0 ]]; then
               $VERBOSE_ECHO "zen-sine-mods: Updated sine mods for profile '${profileName}'"

--- a/package.nix
+++ b/package.nix
@@ -61,7 +61,7 @@
     then "zen-browser"
     else binaryName;
 
-  installDarwin = ''    # bash
+  installDarwin = /* bash */ ''
     runHook preInstall
 
     mkdir -p "$out/Applications" "$out/bin"
@@ -97,7 +97,7 @@
     runHook postInstall
   '';
 
-  installLinux = ''    # bash
+  installLinux = /* bash */ ''
     runHook preInstall
 
     # Linux tarball installation

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -10,7 +10,7 @@
       inherit pkgs home-manager;
       zen-browser-flake = self;
 
-      wrapWithX11 = testScript: ''        # python
+      wrapWithX11 = testScript: /* python */ ''
         machine.succeed("( nohup Xvfb :99 -screen 0 1024x768x24 </dev/null >>/tmp/xvfb.log 2>&1 & )")
         machine.succeed("sleep 2")
         machine.succeed("su - testuser -c 'DISPLAY=:99 timeout 5 zen-beta about:blank' || true")
@@ -53,7 +53,7 @@
         ];
       };
 
-      testScript = ''        # python
+      testScript = /* python */ ''
         machine.wait_for_unit("multi-user.target")
         machine.wait_for_unit("home-manager-testuser.service")
         ${suite.testScript}

--- a/tests/enable-beta.nix
+++ b/tests/enable-beta.nix
@@ -8,7 +8,7 @@
     };
   };
 
-  testScript = ''    # python
+  testScript = /* python */ ''
     machine.succeed("su - testuser -c 'zen-beta --version'")
   '';
 }

--- a/tests/pins-persistent.nix
+++ b/tests/pins-persistent.nix
@@ -29,7 +29,7 @@
     };
   };
 
-  testScript = wrapWithX11 ''    # python
+  testScript = wrapWithX11 /* python */ ''
     machine.succeed("test -f /home/testuser/.config/zen/profiles.ini")
     machine.succeed("grep -q 'Name=default' /home/testuser/.config/zen/profiles.ini")
     machine.succeed("test -d /home/testuser/.config/zen/default")


### PR DESCRIPTION
#261 attempted to introduce language tags, but that did not work for me (in NeoVim, it did not highlight code blocks as expected) and raised a bunch of deprecation warnings by Lix. This introduces them properly (and btw please consider using nixfmt, it is already de-jure standart and adopted in nixpkgs)

```
warning: Whitespace calculations for indentation stripping in a multiline ''-string include the first line, so putting text on it will effectively disable all indentation stripping. To fix this, simply break the line right after the string starts. Use --extra-deprecated-features broken-string-indentation to silence this warning.
         at /nix/store/wxlsi86bzplwnfqvcaxmcc686prncn4n-source/hm-module/places.nix:502:85:
            501|
            502|           updateScript = pkgs.writeShellScript "zen-sessions-update-${profileName}" ''            # bash
               |                                                                                     ^
            503|             SESSIONS_FILE="${sessionsFile}"
```