### PR TITLE
feat(hm): add warnings for pin icon misuse

### DIFF
--- a/examples/10-pinned-tabs.nix
+++ b/examples/10-pinned-tabs.nix
@@ -23,6 +23,7 @@
         isFolderCollapsed = false;
         editedTitle = true;
         position = 200;
+        folderIcon = "chrome://browser/skin/zen-icons/selectable/eye.svg";
       };
       "NixOS Packages" = {
         id = "f8dd784e-11d7-430a-8f57-7b05ecdb4c77";

--- a/hm-module/default.nix
+++ b/hm-module/default.nix
@@ -86,10 +86,38 @@ in {
             "zen.window-sync.sync-only-pinned-tabs" = true;
         ''
         else null;
+
+      pinIconIgnoredWarnings =
+        lib.concatLists (
+          lib.mapAttrsToList (
+            profileName: profile:
+              lib.mapAttrsToList (
+                pinName: pin:
+                  lib.optional ((pin.icon or null) != null) ''
+                    [Zen Browser] '${profileName}' / '${pinName}': `pins.*.icon` does nothing — tab icons are not declarative here; set them in Zen for now. Folders only: `folderIcon` with `isGroup`; workspaces: `spaces.*.icon`.
+                  ''
+              )
+              (profile.pins or {})
+          )
+          cfg.profiles
+        );
+
+      folderIconMisuseWarnings =
+        lib.concatLists (
+          lib.mapAttrsToList (
+            profileName: profile:
+              lib.mapAttrsToList (
+                pinName: pin:
+                  lib.optional ((pin.folderIcon or null) != null && !(pin.isGroup or false)) ''
+                    [Zen Browser] '${profileName}' / '${pinName}': `folderIcon` only applies when `isGroup = true`; ignored here.
+                  ''
+              )
+              (profile.pins or {})
+          )
+          cfg.profiles
+        );
     in
-      lib.filter (w: w != null) [
-        essentialPinsWarning
-      ];
+      lib.filter (w: w != null) ([essentialPinsWarning] ++ pinIconIgnoredWarnings ++ folderIconMisuseWarnings);
 
     assertions =
       [

--- a/hm-module/places.nix
+++ b/hm-module/places.nix
@@ -209,8 +209,27 @@ in {
                             description = "Required boolean flag for folder collapse state, defaults to false";
                           };
                           folderIcon = mkOption {
-                            type = nullOr str;
-                            description = "Emoji or icon URI to be used as pin folder icon.";
+                            type = nullOr (either str path);
+                            description = ''
+                              Folder icon only when `isGroup = true` (sessions `userIcon`). Emoji, `chrome://…`, or path (`file://…`).
+                              Normal pinned tabs: no declarative icon — set in Zen for now; workspaces use `spaces.*.icon`.
+                            '';
+                            apply = v:
+                              if isPath v
+                              then "file://${v}"
+                              else v;
+                            default = null;
+                          };
+                          icon = mkOption {
+                            type = nullOr (either str path);
+                            visible = false;
+                            description = ''
+                              Ignored on pins (warning if set). Tab icons: configure in Zen for now. Folders: `folderIcon`.
+                            '';
+                            apply = v:
+                              if isPath v
+                              then "file://${v}"
+                              else v;
                             default = null;
                           };
                           folderParentId = mkOption {


### PR DESCRIPTION
Hidden pins.icon triggers a short warning; folderIcon outside folder pins warns.

Docs point users to Zen for normal tab icons until declarative support exists.