### PR TITLE
feat(places): enforce joinedTabs tab count 2–3 and fix three-way split sizes

### DIFF
--- a/hm-module/default.nix
+++ b/hm-module/default.nix
@@ -144,10 +144,16 @@ in {
         cfg.profiles)
       ++ (lib.flatten (lib.mapAttrsToList (
           profileName: profile:
-            lib.mapAttrsToList (groupName: group: {
-              assertion = builtins.length group.tabs >= 2;
-              message = "Profile '${profileName}' joinedTabs '${groupName}': at least two tabs are required.";
-            })
+            lib.mapAttrsToList (groupName: group: [
+              {
+                assertion = builtins.length group.tabs >= 2;
+                message = "Profile '${profileName}' joinedTabs '${groupName}': at least two tabs are required.";
+              }
+              {
+                assertion = builtins.length group.tabs <= 3;
+                message = "Profile '${profileName}' joinedTabs '${groupName}': at most three tabs are allowed.";
+              }
+            ])
             (profile.joinedTabs or {})
         )
         cfg.profiles));

--- a/hm-module/places.nix
+++ b/hm-module/places.nix
@@ -264,10 +264,10 @@ in {
                 };
                 joinedTabs = mkOption {
                   description = ''
-                    Split-view groups. Pin IDs listed in any `tabs` array are written to the session
-                    without folder `groupId` (even if those pins use `folderParentId`) so the
-                    split-view `groupId` can apply; the folder row still exists if declared. Zen does
-                    not represent the same tab as both a folder child and a joined split.
+                    Split-view groups (two or three tabs per group). Pin IDs listed in any `tabs` array
+                    are written to the session without folder `groupId` (even if those pins use
+                    `folderParentId`) so the split-view `groupId` can apply; the folder row still exists if
+                    declared. Zen does not represent the same tab as both a folder child and a joined split.
                   '';
                   type = attrsOf (
                     submodule (
@@ -294,8 +294,9 @@ in {
                           tabs = mkOption {
                             type = listOf str;
                             description = ''
-                              Ordered pin UUIDs in this group. Each tab must still be a declared pin;
-                              folder membership is not applied in the session for these IDs.
+                              Ordered pin UUIDs in this group (two or three pins). Each tab must still be
+                              a declared pin; folder membership is not applied in the session for these
+                              IDs.
                             '';
                             default = [];
                           };
@@ -548,7 +549,7 @@ in {
                 sizeInParent =
                   if tabs == []
                   then 100
-                  else 100 / (builtins.length tabs);
+                  else 100.0 / (builtins.length tabs);
               in {
                 groupId = g.id;
                 inherit (g) gridType;

--- a/tests/joined-tabs-with-folder.nix
+++ b/tests/joined-tabs-with-folder.nix
@@ -34,13 +34,21 @@
             folderParentId = folder;
             position = 11;
           };
+          "Center" = {
+            id = "eeeeeeee-eeee-4eee-eeee-eeeeeeeeeeee";
+            url = "https://center.example";
+            title = "Center";
+            workspace = ws;
+            folderParentId = folder;
+            position = 12;
+          };
           "Right" = {
             id = "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb";
             url = "https://right.example";
             title = "Right";
             workspace = ws;
             folderParentId = folder;
-            position = 12;
+            position = 13;
           };
         };
 
@@ -49,6 +57,7 @@
           gridType = "vsep";
           tabs = [
             "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa"
+            "eeeeeeee-eeee-4eee-eeee-eeeeeeeeeeee"
             "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb"
           ];
         };
@@ -84,9 +93,23 @@
       machine.succeed("mozlz4a -d /home/testuser/.config/zen/default/zen-sessions.jsonlz4 /tmp/sessions-folder.json")
       machine.succeed("jq -e '.folders | length == 1' /tmp/sessions-folder.json")
       machine.succeed("jq -e '.folders[0].id == \"{dddddddd-dddd-4ddd-dddd-dddddddddddd}\"' /tmp/sessions-folder.json")
-      machine.succeed("jq -e '.tabs | length == 2' /tmp/sessions-folder.json")
-      machine.succeed("jq -e '[.tabs[].groupId] == [\"1778374511045-84\", \"1778374511045-84\"]' /tmp/sessions-folder.json")
+      machine.succeed("jq -e '.tabs | length == 3' /tmp/sessions-folder.json")
+      machine.succeed(
+        "jq -e '[.tabs[].groupId] == [\"1778374511045-84\", \"1778374511045-84\", \"1778374511045-84\"]' /tmp/sessions-folder.json"
+      )
       machine.succeed("jq -e '.splitViewData | length == 1' /tmp/sessions-folder.json")
+      machine.succeed("jq -e '.splitViewData[0].groupId == \"1778374511045-84\"' /tmp/sessions-folder.json")
+      machine.succeed("jq -e '.splitViewData[0].gridType == \"vsep\"' /tmp/sessions-folder.json")
+      machine.succeed(
+        "jq -e '.splitViewData[0].tabs == [\"{aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa}\", \"{eeeeeeee-eeee-4eee-eeee-eeeeeeeeeeee}\", \"{bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb}\"]' /tmp/sessions-folder.json"
+      )
+      machine.succeed("jq -e '.splitViewData[0].layoutTree.direction == \"row\"' /tmp/sessions-folder.json")
+      machine.succeed(
+        "jq -e '[.splitViewData[0].layoutTree.children[].tabId] == [\"{aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa}\", \"{eeeeeeee-eeee-4eee-eeee-eeeeeeeeeeee}\", \"{bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb}\"]' /tmp/sessions-folder.json"
+      )
+      machine.succeed(
+        "jq -e '[.splitViewData[0].layoutTree.children[].sizeInParent] | length == 3 and (add > 99.9 and add < 100.1)' /tmp/sessions-folder.json"
+      )
       machine.succeed("jq -e '.groups | map(select(.splitView == true)) | length == 1' /tmp/sessions-folder.json")
     '';
 }


### PR DESCRIPTION
Use float division for layoutTree sizeInParent. Extend folder+joined VM test to three tabs. Assert at most three tabs per joined group in the HM module.