### PR TITLE
fix(places): fixed race condition in activation scripts

### DIFF
--- a/hm-module/places.nix
+++ b/hm-module/places.nix
@@ -769,7 +769,12 @@ in {
               rm -f "$BACKUP_FILE"
             '';
         in
-          nameValuePair "zen-sessions-${profileName}" (lib.hm.dag.entryAfter ["writeBoundary"]
+          nameValuePair "zen-sessions-${profileName}" (
+            lib.hm.dag.entryAfter (
+              ["writeBoundary"]
+              (lib.optional (profile.mods != []) "zen-mods-${profileName}")
+              (lib.optional (profile.keyboardShortcuts != []) "zen-keyboard-shortcuts-${profileName}")
+            )
             ''
               ${updateScript}
               if [[ "$?" -eq 0 ]]; then
@@ -780,7 +785,8 @@ in {
                 echo -e "zen-sessions:''${YELLOW} Failed to update zen-sessions.jsonlz4 for Zen browser \"${profileName}\" profile.''${NC}"
                 echo -e "zen-sessions:''${YELLOW} If Zen Browser was open, close it and rebuild to apply changes.''${NC}"
               fi
-            '')
+            ''
+          )
       )
       profilesWithPlaces;
   };


### PR DESCRIPTION
The zen-sessions activation entry was racing with zen-mods and zen-keyboard-shortcuts entries, all running after writeBoundary with no ordering between them. This caused non-deterministic behavior when patching session files

Added dependency ordering using lib.hm.dag to ensure zen-sessions runs after zen-mods and zen-keyboard-shortcuts