### PR TITLE
feat: add programs.zen-browser.env option

### DIFF
--- a/examples/16-environment-variables.nix
+++ b/examples/16-environment-variables.nix
@@ -1,0 +1,12 @@
+# Set environment variables for the Zen Browser launcher (Linux only).
+# Useful for theming/rendering workarounds, e.g. forcing a readable GTK theme
+# under Wayland. See https://github.com/0xc000022070/zen-browser-flake/issues/290
+{
+  programs.zen-browser = {
+    enable = true;
+
+    env = {
+      GTK_THEME = "Adwaita";
+    };
+  };
+}

--- a/hm-module/default.nix
+++ b/hm-module/default.nix
@@ -128,6 +128,10 @@ in {
           message = "The 'icon' option is only supported on Linux.";
         }
         {
+          assertion = cfg.env == {} || pkgs.stdenv.isLinux;
+          message = "The 'env' option is only supported on Linux.";
+        }
+        {
           assertion = !cfg.nixGL.enable || (config.lib ? nixGL && config.lib.nixGL ? wrap);
           message = "You don't meet the requirements to use the 'nixGL.enable' option. See https://github.com/nix-community/nixGL for details.";
         }

--- a/hm-module/package.nix
+++ b/hm-module/package.nix
@@ -18,6 +18,22 @@
   cfg = getAttrFromPath modulePath config;
 
   isSineEnabled = lib.any (profile: profile.sine.enable) (lib.attrValues cfg.profiles);
+
+  envWrapperArgs = lib.concatStringsSep " " (
+    lib.mapAttrsToList (k: v: "--set ${lib.escapeShellArg k} ${lib.escapeShellArg v}") cfg.env
+  );
+
+  applyEnv = pkg:
+    if cfg.env == {} || !pkgs.stdenv.hostPlatform.isLinux
+    then pkg
+    else
+      pkg.overrideAttrs (old: {
+        preFixup =
+          (old.preFixup or "")
+          + ''
+            gappsWrapperArgs+=(${envWrapperArgs})
+          '';
+      });
 in {
   options = setAttrByPath modulePath {
     extraPrefsFiles = mkOption {
@@ -30,6 +46,22 @@ in {
       type = types.str;
       default = "";
       description = "Extra preferences to be included.";
+    };
+
+    env = mkOption {
+      type = types.attrsOf types.str;
+      default = {};
+      example = {
+        GTK_THEME = "Adwaita";
+      };
+      description = ''
+        Environment variables to set when launching Zen Browser. Each entry is
+        injected into the launcher with `makeWrapper --set`, so it applies
+        whether the browser is started from its desktop entry or the command
+        line.
+
+        Only supported on Linux.
+      '';
     };
 
     icon = mkOption {
@@ -66,13 +98,14 @@ in {
   config = mkIf cfg.enable {
     programs.zen-browser = {
       package = let
-        defaultPackage =
+        defaultPackage = applyEnv (
           if cfg.unwrappedPackage != null
           then cfg.unwrappedPackage
           else
             self.packages.${pkgs.stdenv.hostPlatform.system}."${name}-unwrapped".override {
               inherit (cfg) policies enablePrivateDesktopEntry;
-            };
+            }
+        );
 
         getPackage = sine:
           if sine

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -70,6 +70,7 @@
     "joined-tabs-with-folder" = ./joined-tabs-with-folder.nix;
     "default-browser" = ./default-browser.nix;
     "private-desktop-entry" = ./private-desktop-entry.nix;
+    "env-vars" = ./env-vars.nix;
   };
 in
   pkgs.lib.mapAttrs (name: path: mkGenericTest name path) suites

--- a/tests/env-vars.nix
+++ b/tests/env-vars.nix
@@ -1,0 +1,28 @@
+{zen-browser-flake, ...}: {
+  homeModule = {
+    imports = [zen-browser-flake.homeModules.beta];
+
+    programs.zen-browser = {
+      enable = true;
+
+      env = {
+        GTK_THEME = "Adwaita";
+        ZEN_FLAKE_TEST = "marker";
+      };
+    };
+  };
+
+  testScript = ''
+    wrapper = machine.succeed(
+      "su - testuser -c 'readlink -f $(which zen-beta)'"
+    ).strip()
+
+    # The env vars are injected into the unwrapped launcher (a direct reference
+    # of the wrapped package), so they must appear somewhere in the closure.
+    refs = machine.succeed(f"nix-store -q --references {wrapper}").strip().split()
+    haystack = " ".join(refs + [wrapper])
+
+    machine.succeed(f"grep -rqF \"GTK_THEME='Adwaita'\" {haystack}")
+    machine.succeed(f"grep -rqF \"ZEN_FLAKE_TEST='marker'\" {haystack}")
+  '';
+}


### PR DESCRIPTION
Inject env vars into the unwrapped launcher via gappsWrapperArgs before wrapFirefox, so values persist across home-manager's package.override. wrapGAppsHook is absent on Darwin.