### PR TITLE
feat(places): add joinedTabs.<name>.folderParentId option

### DIFF
--- a/examples/15-joined-tabs.nix
+++ b/examples/15-joined-tabs.nix
@@ -27,6 +27,10 @@
       # Optional: explicit per-tab share (percent of parent, must sum to 100).
       # Defaults to equal-split when omitted.
       # sizes = [70 30];
+
+      # Optional: nest the split inside a declared folder pin (isGroup = true)
+      # so it renders as a folder child instead of flat pinned icons.
+      # folderParentId = pins."Some folder".id;
     };
   };
 }

--- a/hm-module/default.nix
+++ b/hm-module/default.nix
@@ -165,6 +165,13 @@ in {
                 assertion = group.sizes == [] || lib.foldl' (a: b: a + b) 0 group.sizes == 100;
                 message = "Profile '${profileName}' joinedTabs '${groupName}': sizes must sum to 100 (got ${toString (lib.foldl' (a: b: a + b) 0 group.sizes)}).";
               }
+              {
+                assertion =
+                  group.folderParentId
+                  == null
+                  || lib.any (p: p.isGroup && p.id == group.folderParentId) (lib.attrValues (profile.pins or {}));
+                message = "Profile '${profileName}' joinedTabs '${groupName}': folderParentId must match the id of a pin with isGroup = true.";
+              }
             ])
             (profile.joinedTabs or {})
         )

--- a/hm-module/places.nix
+++ b/hm-module/places.nix
@@ -310,6 +310,17 @@ in {
                             default = [];
                             example = [70 30];
                           };
+                          folderParentId = mkOption {
+                            type = nullOr str;
+                            description = ''
+                              Pin UUID of a declared folder pin (`isGroup = true`). When set, the split
+                              group gets a `splitViewGroup` folder entry in the session store, so Zen
+                              nests it inside that folder and renders it as a folder child. Without it,
+                              the joined tabs render flat in the pinned section (Zen only nests entries
+                              present in the session `folders` array).
+                            '';
+                            default = null;
+                          };
                         };
                       }
                     )
@@ -404,12 +415,60 @@ in {
             )
             profile.spaces);
 
+          joinedTabIds = flatten (mapAttrsToList (_: g: map wrapTabId g.tabs) profile.joinedTabs);
+
+          # Zen only materializes a folder's tab-group element on restore when
+          # some tab references it via groupId. Folders whose only children are
+          # split groups (or nothing) need the same about:blank placeholder tab
+          # the browser itself creates in ZenFolders.createFolder.
+          folderHasDirectChild = fp:
+            lib.any (
+              p:
+                !p.isGroup
+                && p.folderParentId == fp.id
+                && !(builtins.elem "{${p.id}}" joinedTabIds)
+            ) (lib.attrValues profile.pins);
+
+          childlessGroupPins = filterAttrs (_: p: p.isGroup && !(folderHasDirectChild p)) profile.pins;
+
+          emptyTabEntries =
+            mapAttrsToList (_: fp: {
+              pinned = true;
+              hidden = false;
+              zenWorkspace =
+                if fp.workspace == null
+                then null
+                else "{${fp.workspace}}";
+              zenSyncId = "{${fp.id}}-empty";
+              id = "{${fp.id}}-empty";
+              zenEssential = false;
+              zenDefaultUserContextId = null;
+              zenPinnedIcon = null;
+              zenIsEmpty = true;
+              zenHasStaticIcon = false;
+              zenGlanceId = null;
+              zenIsGlance = false;
+              searchMode = null;
+              userContextId = 0;
+              attributes = {};
+              index = fp.position;
+              lastAccessed = 0;
+              groupId = "{${fp.id}}";
+              entries = [
+                {
+                  url = "about:blank";
+                  triggeringPrincipal_base64 = "{\"3\":{}}";
+                }
+              ];
+            })
+            childlessGroupPins;
+
           pinsJson = toJSON (
             let
               nonGroupPins = filterAttrs (_: p: !p.isGroup) profile.pins;
-              joinedTabIds = flatten (mapAttrsToList (_: g: map wrapTabId g.tabs) profile.joinedTabs);
             in
-              mapAttrsToList (
+              emptyTabEntries
+              ++ mapAttrsToList (
                 _: p:
                   {
                     pinned = true;
@@ -480,30 +539,52 @@ in {
                   collapsed = p.isFolderCollapsed or false;
                   icon = p.folderIcon;
                   index = p.position;
+                  emptyTabIds =
+                    if folderHasDirectChild p
+                    then []
+                    else ["{${p.id}}-empty"];
                 })
                 groupPins;
+              splitViewFolderData =
+                mapAttrsToList (_: g: {
+                  pinned = true;
+                  splitViewGroup = true;
+                  id = g.id;
+                  name = g.name;
+                  collapsed = false;
+                  saveOnWindowClose = true;
+                  parentId = "{${g.folderParentId}}";
+                  prevSiblingInfo = {
+                    type = "start";
+                    id = null;
+                  };
+                  emptyTabIds = [];
+                  workspaceId = null;
+                })
+                (filterAttrs (_: g: g.folderParentId != null) profile.joinedTabs);
             in
-              map (f: {
-                pinned = true;
-                splitViewGroup = false;
-                id = f.id;
-                name = f.name;
-                collapsed = f.collapsed;
-                saveOnWindowClose = true;
-                parentId = f.parentId;
-                prevSiblingInfo = {
-                  type = "start";
-                  id = null;
-                };
-                emptyTabIds = [];
-                userIcon =
-                  if f.icon == null
-                  then ""
-                  else f.icon;
-                workspaceId = f.workspaceId;
-                index = f.index;
-              })
-              folderData
+              (map (f: {
+                  pinned = true;
+                  splitViewGroup = false;
+                  id = f.id;
+                  name = f.name;
+                  collapsed = f.collapsed;
+                  saveOnWindowClose = true;
+                  parentId = f.parentId;
+                  prevSiblingInfo = {
+                    type = "start";
+                    id = null;
+                  };
+                  inherit (f) emptyTabIds;
+                  userIcon =
+                    if f.icon == null
+                    then ""
+                    else f.icon;
+                  workspaceId = f.workspaceId;
+                  index = f.index;
+                })
+                folderData)
+              ++ splitViewFolderData
           );
 
           groupsJson = toJSON (

--- a/tests/joined-tabs-with-folder.nix
+++ b/tests/joined-tabs-with-folder.nix
@@ -55,6 +55,7 @@
         joinedTabs."Inside state" = {
           id = "1778374511045-84";
           gridType = "vsep";
+          folderParentId = folder;
           tabs = [
             "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa"
             "eeeeeeee-eeee-4eee-eeee-eeeeeeeeeeee"
@@ -91,11 +92,22 @@
       machine.wait_for_unit("home-manager-testuser.service")
 
       machine.succeed("mozlz4a -d /home/testuser/.config/zen/default/zen-sessions.jsonlz4 /tmp/sessions-folder.json")
-      machine.succeed("jq -e '.folders | length == 1' /tmp/sessions-folder.json")
-      machine.succeed("jq -e '.folders[0].id == \"{dddddddd-dddd-4ddd-dddd-dddddddddddd}\"' /tmp/sessions-folder.json")
-      machine.succeed("jq -e '.tabs | length == 3' /tmp/sessions-folder.json")
+      machine.succeed("jq -e '.folders | length == 2' /tmp/sessions-folder.json")
       machine.succeed(
-        "jq -e '[.tabs[].groupId] == [\"1778374511045-84\", \"1778374511045-84\", \"1778374511045-84\"]' /tmp/sessions-folder.json"
+        "jq -e '.folders | map(select(.splitViewGroup == false)) | .[0].id == \"{dddddddd-dddd-4ddd-dddd-dddddddddddd}\"' /tmp/sessions-folder.json"
+      )
+      machine.succeed(
+        "jq -e '.folders | map(select(.id == \"1778374511045-84\")) | .[0] | .splitViewGroup == true and .parentId == \"{dddddddd-dddd-4ddd-dddd-dddddddddddd}\" and .pinned == true' /tmp/sessions-folder.json"
+      )
+      machine.succeed("jq -e '.tabs | length == 4' /tmp/sessions-folder.json")
+      machine.succeed(
+        "jq -e '[.tabs[].groupId] == [\"{dddddddd-dddd-4ddd-dddd-dddddddddddd}\", \"1778374511045-84\", \"1778374511045-84\", \"1778374511045-84\"]' /tmp/sessions-folder.json"
+      )
+      machine.succeed(
+        "jq -e '.tabs[] | select(.zenIsEmpty == true) | .groupId == \"{dddddddd-dddd-4ddd-dddd-dddddddddddd}\" and .id == \"{dddddddd-dddd-4ddd-dddd-dddddddddddd}-empty\"' /tmp/sessions-folder.json"
+      )
+      machine.succeed(
+        "jq -e '.folders | map(select(.splitViewGroup == false)) | .[0].emptyTabIds == [\"{dddddddd-dddd-4ddd-dddd-dddddddddddd}-empty\"]' /tmp/sessions-folder.json"
       )
       machine.succeed("jq -e '.splitViewData | length == 1' /tmp/sessions-folder.json")
       machine.succeed("jq -e '.splitViewData[0].groupId == \"1778374511045-84\"' /tmp/sessions-folder.json")


### PR DESCRIPTION
Adds joinedTabs.<name>.folderParentId so split view groups restore nested under a pinned folder instead of flattening into the pinned section, because apparently even browser folders need emotional support structures.

Also preserves empty parent folders by synthesizing the same about:blank placeholder Zen creates normally, preventing SessionStore from dropping childless folders during restore/collect.