### PR TITLE
feat(live-folders): add declarative live folders

### DIFF
--- a/examples/17-live-folders.nix
+++ b/examples/17-live-folders.nix
@@ -1,0 +1,45 @@
+# Live folders: Zen fills the folder with fetched items (RSS feed or GitHub
+# queries). Member tabs are browser-owned — only the container and provider
+# config are declared. State lands in two files that must share the folder id:
+# zen-sessions.jsonlz4 (the sidebar folder row) and zen-live-folders.jsonlz4
+# (provider config). The module writes both; runtime state the browser tracks
+# (lastFetched, dismissed items, discovered repos) survives re-activation.
+#
+# GitHub kinds reuse the browser's logged-in github.com session — no token.
+# Keep "zen.window-sync.enabled" = true (the default) or Zen may drop the
+# entries on restore.
+{
+  programs.zen-browser.profiles.default = {
+    liveFolders = {
+      "Prisma blog" = {
+        id = "0f3f2f66-64bc-4a43-8f86-01c2a134c4f4";
+        kind = "rss";
+        feedUrl = "https://www.prisma.io/blog/rss.xml";
+        folderIcon = "https://www.prisma.io/favicon.ico";
+        position = 400;
+        maxItems = 5;
+        # timeRange = 86400000;   # only items from the last 24 h; 0 (default) keeps all
+        # fetchInterval = 900000; # 15 min; omit to let the browser manage it
+      };
+
+      "Pull requests" = {
+        id = "b7a3d5c1-9e2f-4a68-b0d4-6f1c8e5a2d93";
+        kind = "github:pull-requests";
+        position = 401;
+        github = {
+          assignedMe = true; # default
+          reviewRequested = true;
+          # authorMe = true;
+          # repoExcludes = ["owner/noisy-repo"];
+        };
+      };
+
+      "My issues" = {
+        id = "3c9e1f7a-5b24-4d80-9a6c-e2f4b8d10c57";
+        kind = "github:issues";
+        position = 402;
+        github.authorMe = true;
+      };
+    };
+  };
+}

--- a/hm-module/default.nix
+++ b/hm-module/default.nix
@@ -57,6 +57,7 @@ in {
     })
     (import ./package.nix {inherit self name mkSinePack;})
     (import ./places.nix)
+    (import ./live-folders.nix)
     (import ./keyboard-shortcuts.nix)
     (import ./mods.nix)
     (import ./sine.nix {inherit mkSinePack;})
@@ -84,6 +85,23 @@ in {
           Essentials may not display. Consider enabling window-sync, e.g. with:
             "zen.window-sync.enabled" = true;
             "zen.window-sync.sync-only-pinned-tabs" = true;
+        ''
+        else null;
+
+      liveFoldersWindowSyncWarning = let
+        hasIssue = lib.any (
+          profile:
+            ((profile.settings or {})."zen.window-sync.enabled" or true)
+            == false
+            && (profile.liveFolders or {}) != {}
+        ) (lib.attrValues cfg.profiles);
+      in
+        if hasIssue
+        then ''
+          [Zen Browser] You have liveFolders but window-sync is disabled. Zen restores live
+          folders through the synced window; without it the folder may not attach and Zen
+          can clear zen-live-folders.jsonlz4 on its next save. Consider:
+            "zen.window-sync.enabled" = true;
         ''
         else null;
 
@@ -119,7 +137,7 @@ in {
         cfg.profiles
       );
     in
-      lib.filter (w: w != null) ([essentialPinsWarning] ++ pinIconIgnoredWarnings ++ folderIconMisuseWarnings);
+      lib.filter (w: w != null) ([essentialPinsWarning liveFoldersWindowSyncWarning] ++ pinIconIgnoredWarnings ++ folderIconMisuseWarnings);
 
     assertions =
       [
@@ -175,6 +193,32 @@ in {
             ])
             (profile.joinedTabs or {})
         )
-        cfg.profiles));
+        cfg.profiles))
+      ++ (lib.flatten (lib.mapAttrsToList (
+          profileName: profile:
+            lib.mapAttrsToList (lfName: lf: [
+              {
+                assertion = lf.kind != "rss" || lf.feedUrl != null;
+                message = "Profile '${profileName}' liveFolders '${lfName}': feedUrl is required when kind = \"rss\".";
+              }
+              {
+                assertion = lf.kind == "rss" || lf.feedUrl == null;
+                message = "Profile '${profileName}' liveFolders '${lfName}': feedUrl only applies to kind = \"rss\".";
+              }
+              {
+                assertion = !(lib.any (g: g.id == lf.id) (lib.attrValues (profile.joinedTabs or {})));
+                message = "Profile '${profileName}' liveFolders '${lfName}': id collides with a joinedTabs id.";
+              }
+            ])
+            (profile.liveFolders or {})
+        )
+        cfg.profiles))
+      ++ (lib.mapAttrsToList (profileName: profile: let
+          ids = map (lf: lf.id) (lib.attrValues (profile.liveFolders or {}));
+        in {
+          assertion = builtins.length ids == builtins.length (lib.unique ids);
+          message = "Profile '${profileName}': liveFolders ids must be unique.";
+        })
+        cfg.profiles);
   };
 }

--- a/hm-module/live-folders.nix
+++ b/hm-module/live-folders.nix
@@ -1,0 +1,321 @@
+# Declarative Zen live folders (RSS / GitHub PRs / GitHub issues).
+#
+# Owns the `liveFolders` options and the zen-live-folders.jsonlz4 writer.
+# The matching zen-sessions.jsonlz4 rows (folder row with isLiveFolder,
+# groups row, placeholder empty tab) are produced by places.nix, which owns
+# everything session-store side; both files must share the folder id.
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (lib) getAttrFromPath isPath mkIf mkOption setAttrByPath types;
+
+  modulePath = [
+    "programs"
+    "zen-browser"
+  ];
+
+  cfg = getAttrFromPath modulePath config;
+
+  linuxConfigPath = "${config.xdg.configHome}/zen";
+  darwinConfigPath = "${config.home.homeDirectory}/Library/Application Support/Zen";
+
+  profilePath = "${(
+    if pkgs.stdenv.isDarwin
+    then "${darwinConfigPath}/Profiles"
+    else linuxConfigPath
+  )}";
+in {
+  options = setAttrByPath modulePath {
+    profiles = mkOption {
+      type = with types;
+        attrsOf (
+          submodule (
+            {...}: {
+              options = {
+                liveFolders = mkOption {
+                  description = ''
+                    Live folders (RSS/Atom feed, GitHub pull requests, GitHub issues). Zen fills
+                    the folder with fetched items; member tabs are browser-owned and never
+                    declared. Writes the folder row into `zen-sessions.jsonlz4` and merges the
+                    provider entry into `zen-live-folders.jsonlz4`. Browser runtime state
+                    (`lastFetched`, `dismissedItems`, `tabsState`, discovered GitHub repos) is
+                    preserved on merge; undeclared live folders on disk are kept.
+                  '';
+                  type = attrsOf (
+                    submodule (
+                      {name, ...}: {
+                        options = {
+                          title = mkOption {
+                            type = str;
+                            description = "Sidebar label for the folder.";
+                            default = name;
+                          };
+                          id = mkOption {
+                            type = str;
+                            description = ''
+                              REQUIRED. Stable folder ID, written verbatim to both state files
+                              (like `joinedTabs.*.id`). To adopt a live folder created in Zen,
+                              copy its exact id from the session file.
+                            '';
+                          };
+                          kind = mkOption {
+                            type = enum [
+                              "rss"
+                              "github:pull-requests"
+                              "github:issues"
+                            ];
+                            description = "Live folder provider.";
+                            default = "rss";
+                          };
+                          workspace = mkOption {
+                            type = nullOr str;
+                            default = null;
+                            description = "Workspace ID owning the folder (bare UUID, as in `spaces.*.id`).";
+                          };
+                          position = mkOption {
+                            type = ints.unsigned;
+                            default = 1000;
+                            description = "Position of the folder.";
+                          };
+                          collapsed = mkOption {
+                            type = bool;
+                            default = true;
+                            description = "Whether the folder starts collapsed.";
+                          };
+                          folderIcon = mkOption {
+                            type = nullOr (either str path);
+                            description = "Folder icon (sessions `userIcon`). Emoji, `chrome://…`, or path (`file://…`).";
+                            apply = v:
+                              if isPath v
+                              then "file://${v}"
+                              else v;
+                            default = null;
+                          };
+                          feedUrl = mkOption {
+                            type = nullOr str;
+                            default = null;
+                            description = "RSS or Atom feed URL. Required when `kind = \"rss\"`.";
+                          };
+                          maxItems = mkOption {
+                            type = ints.positive;
+                            default = 10;
+                            description = "RSS only: maximum items shown.";
+                          };
+                          timeRange = mkOption {
+                            type = ints.unsigned;
+                            default = 0;
+                            description = "RSS only: only items newer than this many milliseconds; 0 keeps all.";
+                          };
+                          fetchInterval = mkOption {
+                            type = nullOr ints.positive;
+                            default = null;
+                            description = ''
+                              Refetch interval in milliseconds. Null lets the browser manage it
+                              (30 minutes by default; RSS feeds may tune it via their `ttl`).
+                            '';
+                          };
+                          github = mkOption {
+                            type = submodule {
+                              options = {
+                                authorMe = mkOption {
+                                  type = bool;
+                                  default = false;
+                                  description = "Include items you authored.";
+                                };
+                                assignedMe = mkOption {
+                                  type = bool;
+                                  default = true;
+                                  description = "Include items assigned to you.";
+                                };
+                                reviewRequested = mkOption {
+                                  type = bool;
+                                  default = false;
+                                  description = "Pull requests only: include review requests.";
+                                };
+                                repoExcludes = mkOption {
+                                  type = listOf str;
+                                  default = [];
+                                  description = "`owner/repo` list excluded from the query.";
+                                };
+                              };
+                            };
+                            default = {};
+                            description = "GitHub kinds only; ignored for RSS.";
+                          };
+                        };
+                      }
+                    )
+                  );
+                  default = {};
+                };
+              };
+            }
+          )
+        );
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.activation = let
+      inherit (builtins) toJSON;
+      inherit (lib) filterAttrs getExe mapAttrs' mapAttrsToList nameValuePair optionalAttrs;
+
+      profilesWithLiveFolders = filterAttrs (_: profile: profile.liveFolders != {}) cfg.profiles;
+    in
+      mapAttrs' (
+        profileName: profile: let
+          mozlz4a = getExe pkgs.mozlz4a;
+          jq = getExe pkgs.jq;
+          sessionsFile = "${profilePath}/${profileName}/zen-sessions.jsonlz4";
+          liveFoldersFile = "${profilePath}/${profileName}/zen-live-folders.jsonlz4";
+
+          # Only provider config is declared; the browser fills runtime defaults
+          # (interval, lastFetched, options) on load.
+          liveFoldersJson = toJSON (
+            mapAttrsToList (
+              _: lf: {
+                id = lf.id;
+                type =
+                  if lf.kind == "rss"
+                  then "rss"
+                  else "github";
+                dismissedItems = [];
+                tabsState = [];
+                data.state =
+                  optionalAttrs (lf.fetchInterval != null) {
+                    interval = lf.fetchInterval;
+                  }
+                  // (
+                    if lf.kind == "rss"
+                    then {
+                      url = lf.feedUrl;
+                      inherit (lf) maxItems timeRange;
+                    }
+                    else {
+                      type =
+                        if lf.kind == "github:pull-requests"
+                        then "pull-requests"
+                        else "issues";
+                      options = {
+                        inherit (lf.github) authorMe assignedMe reviewRequested repoExcludes;
+                      };
+                    }
+                  );
+              }
+            )
+            profile.liveFolders
+          );
+
+          liveFoldersJsonFile = pkgs.writeText "zen-declared-live-folders-${profileName}.json" liveFoldersJson;
+
+          # Match by id: declared wins for provider config (type, data.state keys
+          # present in the declared entry — jq * deep-merges objects), browser wins
+          # for runtime state (lastFetched, lastErrorId, isJsonApi, discovered
+          # repos, dismissedItems, tabsState). Unknown ids are appended untouched.
+          jqFilterFile = pkgs.writeText "zen-live-folders-filter-${profileName}.jq" ''
+            ($declaredLiveFolders[0]) as $decl |
+            (if type == "array" then . else [] end) as $existing |
+            ([$existing[].id]) as $eIds |
+
+            [$existing[] |
+              . as $e |
+              ($decl | map(select(.id == $e.id)) | .[0] // null) as $o |
+              if $o != null then ($e * ($o | del(.dismissedItems, .tabsState))) else . end
+            ] + [$decl[] | select(.id as $id | $eIds | index($id) | not)]
+          '';
+
+          updateScript =
+            pkgs.writeShellScript "zen-live-folders-update-${profileName}"
+            ''
+              SESSIONS_FILE="${sessionsFile}"
+              LIVE_FILE="${liveFoldersFile}"
+              LIVE_TMP="$(mktemp)"
+              LIVE_MODIFIED="$(mktemp)"
+              BACKUP_FILE="''${LIVE_FILE}.backup"
+
+              cleanup() {
+                rm -f "$LIVE_TMP" "$LIVE_MODIFIED"
+              }
+
+              restore_and_cleanup() {
+                if [ -f "$BACKUP_FILE" ]; then
+                  mv "$BACKUP_FILE" "$LIVE_FILE"
+                fi
+                cleanup
+              }
+
+              trap cleanup EXIT
+
+              if [ ! -f "$SESSIONS_FILE" ]; then
+                echo "zen-live-folders: Sessions file not found; skipping (live folders need their session folder rows)"
+                exit 0
+              fi
+
+              if pgrep "zen" > /dev/null 2>&1; then
+                echo "zen-live-folders: Zen Browser appears to be running."
+                echo "zen-live-folders: Close Zen Browser and rebuild to apply live folder changes."
+                exit 1
+              fi
+
+              if [ ! -f "$LIVE_FILE" ]; then
+                ${mozlz4a} ${liveFoldersJsonFile} "$LIVE_FILE" || {
+                  echo "zen-live-folders: Failed to create $LIVE_FILE"
+                  exit 1
+                }
+                exit 0
+              fi
+
+              cp "$LIVE_FILE" "$BACKUP_FILE" || {
+                echo "zen-live-folders: Failed to create backup of $LIVE_FILE"
+                exit 1
+              }
+
+              ${mozlz4a} -d "$LIVE_FILE" "$LIVE_TMP" || {
+                echo "zen-live-folders: Failed to decompress $LIVE_FILE"
+                restore_and_cleanup
+                exit 1
+              }
+
+              ${jq} \
+                --slurpfile declaredLiveFolders ${liveFoldersJsonFile} \
+                -f ${jqFilterFile} \
+                "$LIVE_TMP" > "$LIVE_MODIFIED" || {
+                echo "zen-live-folders: Failed to apply modifications to live folders data"
+                restore_and_cleanup
+                exit 1
+              }
+
+              if [ ! -s "$LIVE_MODIFIED" ]; then
+                echo "zen-live-folders: Modified live folders file is empty, restoring backup"
+                restore_and_cleanup
+                exit 1
+              fi
+
+              ${mozlz4a} "$LIVE_MODIFIED" "$LIVE_FILE" || {
+                echo "zen-live-folders: Failed to recompress live folders file"
+                restore_and_cleanup
+                exit 1
+              }
+
+              rm -f "$BACKUP_FILE"
+            '';
+        in
+          nameValuePair "zen-live-folders-${profileName}" (lib.hm.dag.entryAfter ["writeBoundary" "zen-sessions-${profileName}"]
+            ''
+              ${updateScript}
+              if [[ "$?" -eq 0 ]]; then
+                $VERBOSE_ECHO "zen-live-folders: Updated live folders for profile '${profileName}'"
+              else
+                YELLOW="\033[1;33m"
+                NC="\033[0m"
+                echo -e "zen-live-folders:''${YELLOW} Failed to update zen-live-folders.jsonlz4 for Zen browser \"${profileName}\" profile.''${NC}"
+                echo -e "zen-live-folders:''${YELLOW} If Zen Browser was open, close it and rebuild to apply changes.''${NC}"
+              fi
+            '')
+      )
+      profilesWithLiveFolders;
+  };
+}

--- a/hm-module/places.nix
+++ b/hm-module/places.nix
@@ -362,7 +362,8 @@ in {
           || profile.spacesForce
           || profile.pins != {}
           || profile.pinsForce
-          || profile.joinedTabs != {})
+          || profile.joinedTabs != {}
+          || profile.liveFolders != {})
         cfg.profiles;
     in
       mapAttrs' (
@@ -431,16 +432,32 @@ in {
 
           childlessGroupPins = filterAttrs (_: p: p.isGroup && !(folderHasDirectChild p)) profile.pins;
 
-          emptyTabEntries =
+          # Live folders never have declared children (the browser owns them),
+          # so every one gets a placeholder like childless group pins do.
+          placeholderSpecs =
             mapAttrsToList (_: fp: {
+              tabId = "{${fp.id}}-empty";
+              groupId = "{${fp.id}}";
+              inherit (fp) workspace position;
+            })
+            childlessGroupPins
+            ++ mapAttrsToList (_: lf: {
+              tabId = "${lf.id}-empty";
+              groupId = lf.id;
+              inherit (lf) workspace position;
+            })
+            profile.liveFolders;
+
+          emptyTabEntries =
+            map (spec: {
               pinned = true;
               hidden = false;
               zenWorkspace =
-                if fp.workspace == null
+                if spec.workspace == null
                 then null
-                else "{${fp.workspace}}";
-              zenSyncId = "{${fp.id}}-empty";
-              id = "{${fp.id}}-empty";
+                else "{${spec.workspace}}";
+              zenSyncId = spec.tabId;
+              id = spec.tabId;
               zenEssential = false;
               zenDefaultUserContextId = null;
               zenPinnedIcon = null;
@@ -451,9 +468,9 @@ in {
               searchMode = null;
               userContextId = 0;
               attributes = {};
-              index = fp.position;
+              index = spec.position;
               lastAccessed = 0;
-              groupId = "{${fp.id}}";
+              groupId = spec.groupId;
               entries = [
                 {
                   url = "about:blank";
@@ -461,7 +478,7 @@ in {
                 }
               ];
             })
-            childlessGroupPins;
+            placeholderSpecs;
 
           pinsJson = toJSON (
             let
@@ -562,6 +579,32 @@ in {
                   workspaceId = null;
                 })
                 (filterAttrs (_: g: g.folderParentId != null) profile.joinedTabs);
+              liveFolderData =
+                mapAttrsToList (_: lf: {
+                  pinned = true;
+                  splitViewGroup = false;
+                  id = lf.id;
+                  name = lf.title;
+                  collapsed = lf.collapsed;
+                  saveOnWindowClose = true;
+                  parentId = null;
+                  prevSiblingInfo = {
+                    type = "start";
+                    id = null;
+                  };
+                  emptyTabIds = ["${lf.id}-empty"];
+                  userIcon =
+                    if lf.folderIcon == null
+                    then ""
+                    else lf.folderIcon;
+                  workspaceId =
+                    if lf.workspace == null
+                    then null
+                    else "{${lf.workspace}}";
+                  index = lf.position;
+                  isLiveFolder = true;
+                })
+                profile.liveFolders;
             in
               (map (f: {
                   pinned = true;
@@ -585,6 +628,7 @@ in {
                 })
                 folderData)
               ++ splitViewFolderData
+              ++ liveFolderData
           );
 
           groupsJson = toJSON (
@@ -604,6 +648,18 @@ in {
                   inherit (g) id name;
                 })
                 profile.joinedTabs;
+              liveFolderGroupData =
+                mapAttrsToList (_: lf: {
+                  pinned = true;
+                  splitView = false;
+                  id = lf.id;
+                  name = lf.title;
+                  color = "zen-workspace-color";
+                  collapsed = lf.collapsed;
+                  saveOnWindowClose = true;
+                  index = lf.position;
+                })
+                profile.liveFolders;
             in
               (map (f: {
                   pinned = true;
@@ -627,6 +683,7 @@ in {
                   saveOnWindowClose = true;
                 })
                 joinedTabData)
+              ++ liveFolderGroupData
           );
 
           joinedTabsJson = toJSON (

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -68,6 +68,7 @@
     "joined-tabs-sizes" = ./joined-tabs-sizes.nix;
     "joined-tabs-sizes-three-hsep" = ./joined-tabs-sizes-three-hsep.nix;
     "joined-tabs-with-folder" = ./joined-tabs-with-folder.nix;
+    "live-folders" = ./live-folders.nix;
     "default-browser" = ./default-browser.nix;
     "private-desktop-entry" = ./private-desktop-entry.nix;
     "env-vars" = ./env-vars.nix;

--- a/tests/live-folders.nix
+++ b/tests/live-folders.nix
@@ -1,0 +1,141 @@
+{
+  zen-browser-flake,
+  wrapWithX11,
+  ...
+}: {
+  homeModule = {
+    imports = [zen-browser-flake.homeModules.twilight];
+
+    programs.zen-browser = {
+      enable = true;
+      profiles.default = let
+        ws = "cccccccc-cccc-4ccc-cccc-cccccccccccc";
+      in {
+        spaces."Main" = {
+          id = ws;
+          name = "Main";
+          position = 1;
+        };
+
+        liveFolders = {
+          "NixOS blog" = {
+            id = "nixos-blog";
+            kind = "rss";
+            feedUrl = "https://nixos.org/blog/rss.xml";
+            workspace = ws;
+            position = 20;
+            maxItems = 5;
+            folderIcon = "https://nixos.org/favicon.ico";
+          };
+          "Pull requests" = {
+            id = "gh-prs";
+            kind = "github:pull-requests";
+            workspace = ws;
+            position = 21;
+            fetchInterval = 900000;
+            github = {
+              reviewRequested = true;
+              repoExcludes = ["owner/noisy"];
+            };
+          };
+        };
+      };
+    };
+  };
+
+  testScript =
+    wrapWithX11
+    ''
+      machine.succeed("test -d /home/testuser/.config/zen/default")
+
+      machine.succeed(
+          """
+      cat > /tmp/sess-live.json <<'EOF'
+      {
+        "spaces": [],
+        "folders": [],
+        "groups": [],
+        "lastCollected": 0,
+        "splitViewData": [],
+        "tabs": []
+      }
+      EOF
+      mozlz4a /tmp/sess-live.json /home/testuser/.config/zen/default/zen-sessions.jsonlz4
+      chown testuser:users /home/testuser/.config/zen/default/zen-sessions.jsonlz4
+      cat > /tmp/live-pre.json <<'EOF'
+      [
+        {
+          "id": "nixos-blog",
+          "type": "rss",
+          "data": {
+            "state": {
+              "url": "https://example.com/stale.xml",
+              "maxItems": 10,
+              "timeRange": 0,
+              "interval": 1800000,
+              "lastFetched": 4242424242,
+              "lastErrorId": null,
+              "options": {}
+            }
+          },
+          "dismissedItems": ["nixos-blog:/blog/keep-dismissed"],
+          "tabsState": [{"itemId": "nixos-blog:/blog/keep-dismissed", "label": null}]
+        },
+        {
+          "id": "imperative-orphan",
+          "type": "rss",
+          "data": {"state": {"url": "https://example.org/feed.xml"}},
+          "dismissedItems": [],
+          "tabsState": []
+        }
+      ]
+      EOF
+      mozlz4a /tmp/live-pre.json /home/testuser/.config/zen/default/zen-live-folders.jsonlz4
+      chown testuser:users /home/testuser/.config/zen/default/zen-live-folders.jsonlz4
+      """
+      )
+
+      machine.succeed("systemctl restart home-manager-testuser.service")
+      machine.wait_for_unit("home-manager-testuser.service")
+
+      # Session store: folder rows, groups rows, placeholder tabs
+      machine.succeed("mozlz4a -d /home/testuser/.config/zen/default/zen-sessions.jsonlz4 /tmp/sessions-live.json")
+      machine.succeed("jq -e '.folders | length == 2' /tmp/sessions-live.json")
+      machine.succeed(
+        "jq -e '.folders[] | select(.id == \"nixos-blog\") | .isLiveFolder == true and .name == \"NixOS blog\" and .pinned == true and .collapsed == true and .emptyTabIds == [\"nixos-blog-empty\"] and .userIcon == \"https://nixos.org/favicon.ico\" and .workspaceId == \"{cccccccc-cccc-4ccc-cccc-cccccccccccc}\"' /tmp/sessions-live.json"
+      )
+      machine.succeed(
+        "jq -e '.folders[] | select(.id == \"gh-prs\") | .isLiveFolder == true and .index == 21' /tmp/sessions-live.json"
+      )
+      machine.succeed("jq -e '.groups | length == 2' /tmp/sessions-live.json")
+      machine.succeed(
+        "jq -e '.groups[] | select(.id == \"nixos-blog\") | .splitView == false and .pinned == true and .color == \"zen-workspace-color\"' /tmp/sessions-live.json"
+      )
+      machine.succeed("jq -e '[.tabs[] | select(.zenIsEmpty == true)] | length == 2' /tmp/sessions-live.json")
+      machine.succeed(
+        "jq -e '.tabs[] | select(.id == \"nixos-blog-empty\") | .groupId == \"nixos-blog\" and .pinned == true and .entries[0].url == \"about:blank\"' /tmp/sessions-live.json"
+      )
+
+      # Live folders store: declared config applied, runtime state preserved, orphan kept
+      machine.succeed("mozlz4a -d /home/testuser/.config/zen/default/zen-live-folders.jsonlz4 /tmp/live-post.json")
+      machine.succeed("jq -e 'length == 3' /tmp/live-post.json")
+      machine.succeed(
+        "jq -e '.[] | select(.id == \"nixos-blog\") | .data.state.url == \"https://nixos.org/blog/rss.xml\" and .data.state.maxItems == 5' /tmp/live-post.json"
+      )
+      machine.succeed(
+        "jq -e '.[] | select(.id == \"nixos-blog\") | .data.state.lastFetched == 4242424242 and .data.state.interval == 1800000' /tmp/live-post.json"
+      )
+      machine.succeed(
+        "jq -e '.[] | select(.id == \"nixos-blog\") | .dismissedItems == [\"nixos-blog:/blog/keep-dismissed\"] and (.tabsState | length == 1)' /tmp/live-post.json"
+      )
+      machine.succeed(
+        "jq -e '.[] | select(.id == \"gh-prs\") | .type == \"github\" and .data.state.type == \"pull-requests\" and .data.state.interval == 900000' /tmp/live-post.json"
+      )
+      machine.succeed(
+        "jq -e '.[] | select(.id == \"gh-prs\") | .data.state.options == {\"authorMe\": false, \"assignedMe\": true, \"reviewRequested\": true, \"repoExcludes\": [\"owner/noisy\"]} and (.data.state | has(\"url\") | not)' /tmp/live-post.json"
+      )
+      machine.succeed(
+        "jq -e '.[] | select(.id == \"imperative-orphan\") | .data.state.url == \"https://example.org/feed.xml\"' /tmp/live-post.json"
+      )
+    '';
+}


### PR DESCRIPTION
Adds `profiles.<name>.liveFolders` for RSS, GitHub pull request, and GitHub issue live folders.

The module writes provider entries to `zen-live-folders.jsonlz4` while preserving browser-managed runtime state, and emits the matching session rows in `zen-sessions.jsonlz4` so Zen restores them correctly.

Also adds validation for required RSS URLs, unique IDs, joined tab ID collisions, plus an example and VM test coverage.