### PR TITLE
readme: fix package override example

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -95,7 +95,7 @@ inputs.zen-browser.packages."${system}".twilight-official
 
 # you can even override the package policies
 inputs.zen-browser.packages."${system}".default.override {
-  policies = {
+  extraPolicies = {
       DisableAppUpdate = true;
       DisableTelemetry = true;
       # more and more


### PR DESCRIPTION
Fixes the example in README.md. The current example uses policies = { ... } on the .default package, but the wrapped package actually expects extraPolicies.

Because of that, the example was broken, and users trying to apply policies were getting errors. Using the unwrapped package instead breaks the audio on Linux due to missing wrapper libraries.

Relates to #284 