### PR TITLE
fix(hm): replace pgrep with lsof guard

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -194,7 +194,7 @@ If you only declare simple options like policies/extensions/bookmarks, rebuildin
 
 Spaces, pins, and containers are stored in `zen-sessions.jsonlz4` (Mozilla LZ4 compressed JSON). The activation script:
 
-1. Checks if Zen is running via `pgrep "zen"`—exits with error if browser is open
+1. Checks if Zen is running via `lsof path_to_your_profile/.parentlock`—exits with error if browser is open
 2. Decompresses zen-sessions.jsonlz4 from LZ4 to JSON
 3. Modifies it with jq to apply your declared config
 4. Recompresses back to LZ4

--- a/hm-module/live-folders.nix
+++ b/hm-module/live-folders.nix
@@ -256,8 +256,8 @@ in {
               fi
 
               if "${lib.getExe pkgs.lsof}" "$LOCK_FILE" >/dev/null 2>&1; then
-                echo "zen-sessions: Zen Browser appears to be running."
-                echo "zen-sessions: Close Zen Browser and rebuild to apply spaces/pins changes."
+                echo "zen-live-folders: Zen Browser appears to be running."
+                echo "zen-live-folders: Close Zen Browser and rebuild to apply live folder changes."
                 exit 1
               fi
 

--- a/hm-module/live-folders.nix
+++ b/hm-module/live-folders.nix
@@ -235,6 +235,7 @@ in {
               LIVE_TMP="$(mktemp)"
               LIVE_MODIFIED="$(mktemp)"
               BACKUP_FILE="''${LIVE_FILE}.backup"
+              LOCK_FILE="''${SESSIONS_FILE%/*}/.parentlock"
 
               cleanup() {
                 rm -f "$LIVE_TMP" "$LIVE_MODIFIED"
@@ -254,7 +255,7 @@ in {
                 exit 0
               fi
 
-              if "${pkgs.lsof}/bin/lsof" "$LOCK_FILE" >/dev/null 2>&1; then
+              if "${lib.getExe pkgs.lsof}" "$LOCK_FILE" >/dev/null 2>&1; then
                 echo "zen-sessions: Zen Browser appears to be running."
                 echo "zen-sessions: Close Zen Browser and rebuild to apply spaces/pins changes."
                 exit 1

--- a/hm-module/live-folders.nix
+++ b/hm-module/live-folders.nix
@@ -254,9 +254,9 @@ in {
                 exit 0
               fi
 
-              if pgrep "zen" > /dev/null 2>&1; then
-                echo "zen-live-folders: Zen Browser appears to be running."
-                echo "zen-live-folders: Close Zen Browser and rebuild to apply live folder changes."
+              if "${pkgs.lsof}/bin/lsof" "$LOCK_FILE" >/dev/null 2>&1; then
+                echo "zen-sessions: Zen Browser appears to be running."
+                echo "zen-sessions: Close Zen Browser and rebuild to apply spaces/pins changes."
                 exit 1
               fi
 

--- a/hm-module/places.nix
+++ b/hm-module/places.nix
@@ -862,7 +862,7 @@ in {
                 exit 0
               fi
 
-              if pgrep "zen" > /dev/null 2>&1; then
+              if "${pkgs.lsof}/bin/lsof" -- "${profilePath}/${profileName}/.parentlock" >/dev/null 2>&1; then
                 echo "zen-sessions: Zen Browser appears to be running."
                 echo "zen-sessions: Close Zen Browser and rebuild to apply spaces/pins changes."
                 exit 1

--- a/hm-module/places.nix
+++ b/hm-module/places.nix
@@ -842,6 +842,7 @@ in {
               SESSIONS_TMP="$(mktemp)"
               SESSIONS_MODIFIED="$(mktemp)"
               BACKUP_FILE="''${SESSIONS_FILE}.backup"
+              LOCK_FILE="''${SESSIONS_FILE%/*}/.parentlock"
 
               cleanup() {
                 rm -f "$SESSIONS_TMP" "$SESSIONS_MODIFIED"
@@ -862,7 +863,7 @@ in {
                 exit 0
               fi
 
-              if "${pkgs.lsof}/bin/lsof" -- "${profilePath}/${profileName}/.parentlock" >/dev/null 2>&1; then
+              if "${pkgs.lsof}/bin/lsof" "$LOCK_FILE" >/dev/null 2>&1; then
                 echo "zen-sessions: Zen Browser appears to be running."
                 echo "zen-sessions: Close Zen Browser and rebuild to apply spaces/pins changes."
                 exit 1

--- a/hm-module/places.nix
+++ b/hm-module/places.nix
@@ -863,7 +863,7 @@ in {
                 exit 0
               fi
 
-              if "${pkgs.lsof}/bin/lsof" "$LOCK_FILE" >/dev/null 2>&1; then
+              if "${lib.getExe pkgs.lsof}" "$LOCK_FILE" >/dev/null 2>&1; then
                 echo "zen-sessions: Zen Browser appears to be running."
                 echo "zen-sessions: Close Zen Browser and rebuild to apply spaces/pins changes."
                 exit 1


### PR DESCRIPTION
Replaces `pgrep "zen"` guard with `lsof`

Tested on NixOS