### PR TITLE
fix(hm): exit 0 when zen is running during activation

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -194,7 +194,7 @@ If you only declare simple options like policies/extensions/bookmarks, rebuildin
 
 Spaces, pins, and containers are stored in `zen-sessions.jsonlz4` (Mozilla LZ4 compressed JSON). The activation script:
 
-1. Checks if Zen is running via `lsof path_to_your_profile/.parentlock`—exits with error if browser is open
+1. Checks if Zen is running via `lsof path_to_your_profile/.parentlock`—skips the update with a warning (activation still succeeds) if browser is open
 2. Decompresses zen-sessions.jsonlz4 from LZ4 to JSON
 3. Modifies it with jq to apply your declared config
 4. Recompresses back to LZ4

--- a/hm-module/live-folders.nix
+++ b/hm-module/live-folders.nix
@@ -256,9 +256,9 @@ in {
               fi
 
               if "${lib.getExe pkgs.lsof}" "$LOCK_FILE" >/dev/null 2>&1; then
-                echo "zen-live-folders: Zen Browser appears to be running."
-                echo "zen-live-folders: Close Zen Browser and rebuild to apply live folder changes."
-                exit 1
+                echo "zen-live-folders: Zen Browser appears to be running; skipping live folder changes."
+                echo "zen-live-folders: Close Zen Browser and rebuild to apply them."
+                exit 0
               fi
 
               if [ ! -f "$LIVE_FILE" ]; then

--- a/hm-module/places.nix
+++ b/hm-module/places.nix
@@ -864,9 +864,9 @@ in {
               fi
 
               if "${lib.getExe pkgs.lsof}" "$LOCK_FILE" >/dev/null 2>&1; then
-                echo "zen-sessions: Zen Browser appears to be running."
-                echo "zen-sessions: Close Zen Browser and rebuild to apply spaces/pins changes."
-                exit 1
+                echo "zen-sessions: Zen Browser appears to be running; skipping spaces/pins changes."
+                echo "zen-sessions: Close Zen Browser and rebuild to apply them."
+                exit 0
               fi
 
               cp "$SESSIONS_FILE" "$BACKUP_FILE" || {


### PR DESCRIPTION
The lsof running guard in the zen-sessions and zen-live-folders activation scripts exited 1, which aborts home-manager activation under set -e and makes home-manager/nh report failure. Change only the running-guard branch to warn and exit 0, skipping the update. All other failure paths (backup, decompress, jq, recompress) still exit 1.

Related to #336