### PR TITLE
chore(hm-module): drop suppressXdgMigrationWarning removed-option stub

### DIFF
--- a/hm-module/default.nix
+++ b/hm-module/default.nix
@@ -62,11 +62,6 @@ in {
     (import ./mods.nix)
     (import ./sine.nix {inherit mkSinePack;})
     (import ./default-browser.nix {inherit name;})
-    (lib.mkRemovedOptionModule [
-      "programs"
-      "zen-browser"
-      "suppressXdgMigrationWarning"
-    ] "The XDG migration stage has ended.")
   ];
 
   config = mkIf cfg.enable {


### PR DESCRIPTION
The option was deprecated via mkRemovedOptionModule in #277 (March 2026) after the XDG migration stage ended. Four months later the stub is no longer needed.