### PR TITLE
feat(hm): support embedded folder pins via pins.<name>.pins

### DIFF
--- a/examples/10-pinned-tabs.nix
+++ b/examples/10-pinned-tabs.nix
@@ -4,6 +4,12 @@
 #   - `spaces.<name>.pins`, same options minus `workspace` (derived from
 #     the owning space's `id`); participates in `pinsForce` accounting
 #     like any other declared pin
+# Folders, two forms, freely mixable:
+#   - embedded: nest children under the folder pin's `pins` — `isGroup` is
+#     implied, children inherit `workspace` and `folderParentId`, nesting
+#     can go deeper
+#   - flat: declare the folder with `isGroup = true` and point siblings at
+#     it via `folderParentId = pins."<folder>".id`
 #
 # ⚠ Only if using pins or pinsForce: close Zen before home-manager switch
 # (activation script needs exclusive access to modify zen-sessions.jsonlz4)
@@ -16,25 +22,33 @@
         position = 101;
         isEssential = true;
       };
+
+      # Embedded form: children live inside the folder pin.
       "Dev Tools" = {
         id = "d85a9026-1458-4db6-b115-346746bcc692";
-        isGroup = true;
         isFolderCollapsed = false;
         editedTitle = true;
         position = 200;
         folderIcon = "chrome://browser/skin/zen-icons/selectable/eye.svg";
+
+        pins."NixOS Packages" = {
+          id = "f8dd784e-11d7-430a-8f57-7b05ecdb4c77";
+          url = "https://search.nixos.org/packages";
+          position = 201;
+        };
       };
-      "NixOS Packages" = {
-        id = "f8dd784e-11d7-430a-8f57-7b05ecdb4c77";
-        url = "https://search.nixos.org/packages";
-        folderParentId = pins."Dev Tools".id;
-        position = 201;
+
+      # Flat form: same result, folder and child are siblings.
+      "Reference" = {
+        id = "6b8f0d24-93a1-4c5e-b7d2-08e4f61a9c35";
+        isGroup = true;
+        position = 300;
       };
       "NixOS Options" = {
         id = "92931d60-fd40-4707-9512-a57b1a6a3919";
         url = "https://search.nixos.org/options";
-        folderParentId = pins."Dev Tools".id;
-        position = 202;
+        folderParentId = pins."Reference".id;
+        position = 301;
       };
     };
   in {

--- a/hm-module/default.nix
+++ b/hm-module/default.nix
@@ -74,7 +74,7 @@ in {
           profile:
             ((profile.settings or {})."zen.window-sync.enabled" or true)
             == false
-            && lib.any (p: p.isEssential or false) (lib.attrValues (profile.pins or {}))
+            && lib.any (p: p.isEssential or false) (lib.attrValues (profile.pinsResolved or {}))
         ) (lib.attrValues cfg.profiles);
       in
         if hasIssue
@@ -113,7 +113,23 @@ in {
                     [Zen Browser] '${profileName}' / '${pinName}': `pins.*.icon` does nothing — tab icons are not declarative here; set them in Zen for now. Folders only: `folderIcon` with `isGroup`; workspaces: `spaces.*.icon`.
                   ''
               )
-              (profile.pins or {})
+              (profile.pinsResolved or {})
+            )
+        )
+        cfg.profiles
+      );
+
+      urlOnFolderWarnings = lib.concatLists (
+        lib.mapAttrsToList (
+          profileName: profile:
+            lib.concatLists (
+              lib.mapAttrsToList (
+                pinName: pin:
+                  lib.optional (pin.isGroup && (pin.url or null) != null) ''
+                    [Zen Browser] '${profileName}' / '${pinName}': `url` does nothing on a folder pin — folders have no page. Note that nesting child pins under a pin makes it a folder (`isGroup` is implied).
+                  ''
+              )
+              (profile.pinsResolved or {})
             )
         )
         cfg.profiles
@@ -129,13 +145,13 @@ in {
                     [Zen Browser] '${profileName}' / '${pinName}': `folderIcon` only applies when `isGroup = true`; ignored here.
                   ''
               )
-              (profile.pins or {})
+              (profile.pinsResolved or {})
             )
         )
         cfg.profiles
       );
     in
-      lib.filter (w: w != null) ([essentialPinsWarning liveFoldersWindowSyncWarning] ++ pinIconIgnoredWarnings ++ folderIconMisuseWarnings);
+      lib.filter (w: w != null) ([essentialPinsWarning liveFoldersWindowSyncWarning] ++ pinIconIgnoredWarnings ++ urlOnFolderWarnings ++ folderIconMisuseWarnings);
 
     assertions =
       [
@@ -185,7 +201,7 @@ in {
                 assertion =
                   group.folderParentId
                   == null
-                  || lib.any (p: p.isGroup && p.id == group.folderParentId) (lib.attrValues (profile.pins or {}));
+                  || lib.any (p: p.isGroup && p.id == group.folderParentId) (lib.attrValues (profile.pinsResolved or {}));
                 message = "Profile '${profileName}' joinedTabs '${groupName}': folderParentId must match the id of a pin with isGroup = true.";
               }
             ])
@@ -217,6 +233,15 @@ in {
           assertion = builtins.length ids == builtins.length (lib.unique ids);
           message = "Profile '${profileName}': liveFolders ids must be unique.";
         })
-        cfg.profiles);
+        cfg.profiles)
+      ++ (lib.flatten (lib.mapAttrsToList (
+          profileName: profile:
+            lib.mapAttrsToList (pinName: pin: {
+              assertion = !(pin.isEssential && pin.folderParentId != null);
+              message = "Profile '${profileName}' pins '${pinName}': essential pins live in the essentials strip and cannot be inside a folder (isEssential = true with a folder parent).";
+            })
+            (profile.pinsResolved or {})
+        )
+        cfg.profiles));
   };
 }

--- a/hm-module/lib/pin-options.nix
+++ b/hm-module/lib/pin-options.nix
@@ -1,11 +1,20 @@
 # Pin submodule shared by `pins` and the space-scoped `spaces.*.pins`.
 # Space-scoped pins exclude `workspace`: it is derived from the owning
-# space during desugaring (session/spaces.nix).
+# space during desugaring (session/spaces.nix). Child pins (`pins.*.pins`)
+# exclude both `workspace` and `folderParentId`: they are inherited from
+# the owning folder pin during resolution (lib/resolve-pins.nix).
 {
   lib,
   includeWorkspace ? true,
+  includeFolderParent ? true,
 }: let
   inherit (lib) isPath mkOption types;
+
+  childPinModule = import ./pin-options.nix {
+    inherit lib;
+    includeWorkspace = false;
+    includeFolderParent = false;
+  };
 in
   {name, ...}: {
     options = with types;
@@ -78,6 +87,19 @@ in
             else v;
           default = null;
         };
+        pins = mkOption {
+          type = attrsOf (submodule childPinModule);
+          # shallow: the type is recursive; documenting sub-options would never terminate.
+          visible = "shallow";
+          default = {};
+          description = ''
+            Child pins nested under this pin, making it a folder (`isGroup` is implied).
+            Same options as `pins.*` except `workspace` and `folderParentId`, which are
+            inherited from this pin. Nest further for folders inside folders.
+          '';
+        };
+      }
+      // lib.optionalAttrs includeFolderParent {
         folderParentId = mkOption {
           type = nullOr str;
           default = null;

--- a/hm-module/lib/resolve-pins.nix
+++ b/hm-module/lib/resolve-pins.nix
@@ -2,10 +2,14 @@
 # producers consume. Children get `folderParentId` and `workspace` from the
 # owning folder pin, a pin with children is a folder (`isGroup` implied),
 # and keys extend the parent key: "State" -> "State/Cursor".
+# Folder nesting is capped at `maxSubfolders` (Zen's
+# zen.folders.max-subfolders): the throw doubles as a termination guard,
+# so a self-referential (lazily infinite) pin tree fails instead of
+# hanging evaluation.
 {lib}: let
   inherit (lib) concatLists listToAttrs mapAttrsToList nameValuePair optionalAttrs;
 
-  go = prefix: parent: pins:
+  go = maxSubfolders: prefix: parent: depth: pins:
     concatLists (mapAttrsToList (
         name: p: let
           key =
@@ -21,12 +25,17 @@
             };
         in
           [(nameValuePair key resolved)]
-          ++ go key {
-            id = p.id;
-            workspace = resolved.workspace;
-          }
-          p.pins
+          ++ (
+            if p.pins != {} && depth > maxSubfolders
+            then throw "zen-browser: pin folder '${key}' exceeds zen.folders.max-subfolders (${toString maxSubfolders}); Zen cannot nest folders this deep."
+            else
+              go maxSubfolders key {
+                id = p.id;
+                workspace = resolved.workspace;
+              } (depth + 1)
+              p.pins
+          )
       )
       pins);
 in
-  pins: listToAttrs (go null null pins)
+  maxSubfolders: pins: listToAttrs (go maxSubfolders null null 0 pins)

--- a/hm-module/lib/resolve-pins.nix
+++ b/hm-module/lib/resolve-pins.nix
@@ -1,0 +1,32 @@
+# Flattens the nested pin tree (`pins.*.pins`) into the flat attrset the
+# producers consume. Children get `folderParentId` and `workspace` from the
+# owning folder pin, a pin with children is a folder (`isGroup` implied),
+# and keys extend the parent key: "State" -> "State/Cursor".
+{lib}: let
+  inherit (lib) concatLists listToAttrs mapAttrsToList nameValuePair optionalAttrs;
+
+  go = prefix: parent: pins:
+    concatLists (mapAttrsToList (
+        name: p: let
+          key =
+            if prefix == null
+            then name
+            else "${prefix}/${name}";
+          resolved =
+            removeAttrs p ["pins"]
+            // {isGroup = p.isGroup || p.pins != {};}
+            // optionalAttrs (parent != null) {
+              folderParentId = parent.id;
+              workspace = parent.workspace;
+            };
+        in
+          [(nameValuePair key resolved)]
+          ++ go key {
+            id = p.id;
+            workspace = resolved.workspace;
+          }
+          p.pins
+      )
+      pins);
+in
+  pins: listToAttrs (go null null pins)

--- a/hm-module/session/pins.nix
+++ b/hm-module/session/pins.nix
@@ -78,8 +78,9 @@ in {
                   ) (attrValues config.pinsResolved);
 
                 childlessGroupPins = filterAttrs (_: p: p.isGroup && !(folderHasDirectChild p)) config.pinsResolved;
+                maxSubfolders = (config.settings or {})."zen.folders.max-subfolders" or 5;
               in {
-                pinsResolved = resolvePins config.pins;
+                pinsResolved = resolvePins maxSubfolders config.pins;
 
                 sessionStore.tabs =
                   mapAttrsToList (_: fp:

--- a/hm-module/session/pins.nix
+++ b/hm-module/session/pins.nix
@@ -7,6 +7,7 @@
   ];
 
   pinModule = import ../lib/pin-options.nix {inherit lib;};
+  resolvePins = import ../lib/resolve-pins.nix {inherit lib;};
   rows = import ../lib/session-rows.nix {inherit lib;};
 in {
   options = setAttrByPath modulePath {
@@ -44,6 +45,16 @@ in {
                   type = attrsOf (submodule pinModule);
                   default = {};
                 };
+                pinsResolved = mkOption {
+                  type = lazyAttrsOf raw;
+                  internal = true;
+                  readOnly = true;
+                  description = ''
+                    Flat view of `pins` with nested child pins (`pins.*.pins`) resolved:
+                    `folderParentId` and `workspace` inherited from the owning folder pin,
+                    `isGroup` implied by children. Consumers read this, never `pins`.
+                  '';
+                };
               };
 
               config = let
@@ -52,8 +63,8 @@ in {
 
                 joinedTabIds = config.sessionStore.joinedTabIds;
 
-                nonGroupPins = filterAttrs (_: p: !p.isGroup) config.pins;
-                groupPins = filterAttrs (_: p: p.isGroup) config.pins;
+                nonGroupPins = filterAttrs (_: p: !p.isGroup) config.pinsResolved;
+                groupPins = filterAttrs (_: p: p.isGroup) config.pinsResolved;
 
                 # A pin owned by a split group carries the group's groupId, not the
                 # folder's, so it doesn't keep the folder alive on restore — such
@@ -64,10 +75,12 @@ in {
                       !p.isGroup
                       && p.folderParentId == fp.id
                       && !(elem "{${p.id}}" joinedTabIds)
-                  ) (attrValues config.pins);
+                  ) (attrValues config.pinsResolved);
 
-                childlessGroupPins = filterAttrs (_: p: p.isGroup && !(folderHasDirectChild p)) config.pins;
+                childlessGroupPins = filterAttrs (_: p: p.isGroup && !(folderHasDirectChild p)) config.pinsResolved;
               in {
+                pinsResolved = resolvePins config.pins;
+
                 sessionStore.tabs =
                   mapAttrsToList (_: fp:
                     rows.mkEmptyTabRow {

--- a/tests/space-scoped-pins.nix
+++ b/tests/space-scoped-pins.nix
@@ -45,6 +45,19 @@
                 url = "https://search.nixos.org/packages";
                 position = 201;
               };
+
+              # Embedded folder: isGroup implied, children inherit
+              # workspace + folderParentId.
+              "Tools" = {
+                id = "bbbb0001-0000-4000-8000-00000000000c";
+                position = 300;
+
+                pins."Hydra" = {
+                  id = "bbbb0002-0000-4000-8000-00000000000d";
+                  url = "https://hydra.nixos.org";
+                  position = 301;
+                };
+              };
             };
           };
         };
@@ -114,8 +127,17 @@
         "jq -e '.tabs[] | select(.zenSyncId == \"{92931d60-fd40-4707-9512-a57b1a6a3919}\") | .zenWorkspace == \"{aaaa0002-0000-4000-8000-00000000000b}\"' /tmp/sessions.json"
       )
 
+      # Embedded folder: child tab carries the folder's groupId and the space's
+      # workspace; the folder row lands in the space with no placeholder tab
+      machine.succeed(
+        "jq -e '.tabs[] | select(.zenSyncId == \"{bbbb0002-0000-4000-8000-00000000000d}\") | .groupId == \"{bbbb0001-0000-4000-8000-00000000000c}\" and .zenWorkspace == \"{aaaa0002-0000-4000-8000-00000000000b}\"' /tmp/sessions.json"
+      )
+      machine.succeed(
+        "jq -e '.folders[] | select(.id == \"{bbbb0001-0000-4000-8000-00000000000c}\") | .workspaceId == \"{aaaa0002-0000-4000-8000-00000000000b}\" and .emptyTabIds == []' /tmp/sessions.json"
+      )
+
       # pinsForce=remove counts nested pins as declared: they survive, the orphan does not
-      machine.succeed("jq -e '[.tabs[] | select(.pinned == true)] | length == 4' /tmp/sessions.json")
+      machine.succeed("jq -e '[.tabs[] | select(.pinned == true)] | length == 5' /tmp/sessions.json")
       machine.succeed(
         "jq -e '[.tabs[] | select(.zenSyncId == \"{deadbeef-0000-4000-8000-000000000000}\")] | length == 0' /tmp/sessions.json"
       )


### PR DESCRIPTION
Add a recursive pins option to the pin submodule; children exclude workspace and folderParentId (inherited from the owning folder) and imply isGroup on the parent. New lib/resolve-pins.nix flattens the tree into the internal pinsResolved option, which row generation, warnings and assertions now read instead of pins. Assert essential pins cannot have a folder parent; warn when url is set on a folder pin.