### PR TITLE
feat(hm): require workspace on profile-level liveFolders

### DIFF
--- a/examples/13-complete-setup.nix
+++ b/examples/13-complete-setup.nix
@@ -132,12 +132,14 @@
           height: 16px;
         }
       '';
+      # workspace is required: every live folder belongs to exactly one space.
       liveFolders = {
         "Prisma blog" = {
           id = "0f3f2f66-64bc-4a43-8f86-01c2a134c4f4";
           kind = "rss";
           feedUrl = "https://www.prisma.io/blog/rss.xml";
           folderIcon = "https://www.prisma.io/favicon.ico";
+          workspace = "c6de089c-410d-4206-961d-ab11f988d40a"; # General
           position = 400;
           maxItems = 5;
         };
@@ -145,6 +147,7 @@
         "Pull requests" = {
           id = "b7a3d5c1-9e2f-4a68-b0d4-6f1c8e5a2d93";
           kind = "github:pull-requests";
+          workspace = "cdd10fab-4fc5-494b-9041-325e5759195b"; # Work
           position = 401;
           github = {
             assignedMe = true; # default
@@ -155,6 +158,7 @@
         "My issues" = {
           id = "3c9e1f7a-5b24-4d80-9a6c-e2f4b8d10c57";
           kind = "github:issues";
+          workspace = "cdd10fab-4fc5-494b-9041-325e5759195b"; # Work
           position = 402;
           github.authorMe = true;
         };

--- a/examples/17-live-folders.nix
+++ b/examples/17-live-folders.nix
@@ -5,17 +5,24 @@
 # (provider config). The module writes both; runtime state the browser tracks
 # (lastFetched, dismissed items, discovered repos) survives re-activation.
 #
+# Every live folder belongs to exactly one space, so `workspace` is required
+# at profile level. Without declared spaces, copy Zen's auto-created space id
+# from the `zen.workspaces.active` pref in about:config, minus the braces.
+#
 # GitHub kinds reuse the browser's logged-in github.com session — no token.
 # Keep "zen.window-sync.enabled" = true (the default) or Zen may drop the
 # entries on restore.
 {
-  programs.zen-browser.profiles.default = {
+  programs.zen-browser.profiles.default = let
+    workSpaceId = "8a2c47f0-1d9e-4b36-a5c8-f70e92b4d615";
+  in {
     liveFolders = {
       "Prisma blog" = {
         id = "0f3f2f66-64bc-4a43-8f86-01c2a134c4f4";
         kind = "rss";
         feedUrl = "https://www.prisma.io/blog/rss.xml";
         folderIcon = "https://www.prisma.io/favicon.ico";
+        workspace = workSpaceId;
         position = 400;
         maxItems = 5;
         # timeRange = 86400000;   # only items from the last 24 h; 0 (default) keeps all
@@ -25,6 +32,7 @@
       "Pull requests" = {
         id = "b7a3d5c1-9e2f-4a68-b0d4-6f1c8e5a2d93";
         kind = "github:pull-requests";
+        workspace = workSpaceId;
         position = 401;
         github = {
           assignedMe = true; # default
@@ -37,6 +45,7 @@
       "My issues" = {
         id = "3c9e1f7a-5b24-4d80-9a6c-e2f4b8d10c57";
         kind = "github:issues";
+        workspace = workSpaceId;
         position = 402;
         github.authorMe = true;
       };
@@ -45,7 +54,7 @@
     # Space-scoped form: same options as liveFolders.* except workspace,
     # which is set to the owning space's id automatically.
     spaces."Work" = {
-      id = "8a2c47f0-1d9e-4b36-a5c8-f70e92b4d615";
+      id = workSpaceId;
 
       liveFolders."Team PRs" = {
         id = "e5b81c39-7f42-4d0a-96e3-2a8c50d17b64";

--- a/hm-module/default.nix
+++ b/hm-module/default.nix
@@ -219,6 +219,10 @@ in {
                 assertion = lf.kind == "rss" || lf.feedUrl == null;
                 message = "Profile '${profileName}' liveFolders '${lfName}': feedUrl only applies to kind = \"rss\".";
               }
+              {
+                assertion = lf.workspace or null != null;
+                message = "Profile '${profileName}' liveFolders '${lfName}': workspace is required — Zen folders belong to exactly one space. Use spaces.<name>.liveFolders, or set workspace to a space id (without declared spaces: copy the zen.workspaces.active pref from about:config, minus the braces).";
+              }
             ])
             (profile.liveFolders or {})
         )

--- a/hm-module/lib/live-folder-options.nix
+++ b/hm-module/lib/live-folder-options.nix
@@ -107,7 +107,12 @@ in
         workspace = mkOption {
           type = nullOr str;
           default = null;
-          description = "Workspace ID owning the folder (bare UUID, as in `spaces.*.id`).";
+          description = ''
+            REQUIRED. Workspace ID owning the folder (bare UUID, as in
+            `spaces.*.id`); Zen folders belong to exactly one space. Without
+            declared spaces, copy Zen's auto-created space id from the
+            `zen.workspaces.active` pref in `about:config`, minus the braces.
+          '';
         };
       };
   }


### PR DESCRIPTION
Add an assertion rejecting liveFolders entries with a null workspace: Zen folders belong to exactly one space, and a missing workspaceId made the folder adopt whichever space was last active at restore. Point the message at spaces.<name>.liveFolders or the zen.workspaces.active pref. Mark the option REQUIRED in its description and set workspace in the examples.

Fixes #346