### PR TITLE
fix(hm): resolve profile state dirs from profiles.<name>.path

### DIFF
--- a/hm-module/keyboard-shortcuts.nix
+++ b/hm-module/keyboard-shortcuts.nix
@@ -12,15 +12,6 @@
   ];
 
   cfg = getAttrFromPath modulePath config;
-
-  linuxConfigPath = "${config.xdg.configHome}/zen";
-  darwinConfigPath = "${config.home.homeDirectory}/Library/Application Support/Zen";
-
-  profilePath = "${(
-    if pkgs.stdenv.isDarwin
-    then "${darwinConfigPath}/Profiles"
-    else linuxConfigPath
-  )}";
 in {
   options = setAttrByPath modulePath {
     profiles = mkOption {
@@ -134,8 +125,8 @@ in {
       mapAttrs'
       (
         profileName: profile: let
-          shortcutsFilePath = "${profilePath}/${profileName}/zen-keyboard-shortcuts.json";
-          prefsFile = "${profilePath}/${profileName}/prefs.js";
+          shortcutsFilePath = "${cfg.profilesPath}/${profile.path}/zen-keyboard-shortcuts.json";
+          prefsFile = "${cfg.profilesPath}/${profile.path}/prefs.js";
 
           shortcutToJson = shortcut: {
             inherit (shortcut) id;

--- a/hm-module/mods.nix
+++ b/hm-module/mods.nix
@@ -12,15 +12,6 @@
   ];
 
   cfg = getAttrFromPath modulePath config;
-
-  linuxConfigPath = "${config.xdg.configHome}/zen";
-  darwinConfigPath = "${config.home.homeDirectory}/Library/Application Support/Zen";
-
-  profilePath = "${(
-    if pkgs.stdenv.isDarwin
-    then "${darwinConfigPath}/Profiles"
-    else linuxConfigPath
-  )}";
 in {
   options = setAttrByPath modulePath {
     profiles = mkOption {
@@ -58,14 +49,14 @@ in {
       mapAttrs'
       (
         profileName: profile: let
-          themesFilePath = "${profilePath}/${profileName}/zen-themes.json";
+          themesFilePath = "${cfg.profilesPath}/${profile.path}/zen-themes.json";
 
           updateModsScript =
             pkgs.writeShellScript "zen-mods-update-${profileName}"
             ''
                         THEMES_FILE="${themesFilePath}"
                         MODS="${lib.concatStringsSep " " profile.mods}"
-                        BASE_DIR="${profilePath}/${profileName}"
+                        BASE_DIR="${cfg.profilesPath}/${profile.path}"
                         MANAGED_FILE="$BASE_DIR/zen-mods-nix-managed.json"
 
                         if [ ! -f "$THEMES_FILE" ]; then

--- a/hm-module/session/live-folders.nix
+++ b/hm-module/session/live-folders.nix
@@ -15,15 +15,6 @@
 
   cfg = getAttrFromPath modulePath config;
 
-  linuxConfigPath = "${config.xdg.configHome}/zen";
-  darwinConfigPath = "${config.home.homeDirectory}/Library/Application Support/Zen";
-
-  profilePath = "${(
-    if pkgs.stdenv.isDarwin
-    then "${darwinConfigPath}/Profiles"
-    else linuxConfigPath
-  )}";
-
   mkJsonlz4Updater = import ../lib/state-writer.nix {inherit pkgs lib;};
   rows = import ../lib/session-rows.nix {inherit lib;};
   liveFolderModule = import ../lib/live-folder-options.nix {inherit lib;};
@@ -117,8 +108,8 @@ in {
     in
       mapAttrs' (
         profileName: profile: let
-          sessionsFile = "${profilePath}/${profileName}/zen-sessions.jsonlz4";
-          liveFoldersFile = "${profilePath}/${profileName}/zen-live-folders.jsonlz4";
+          sessionsFile = "${cfg.profilesPath}/${profile.path}/zen-sessions.jsonlz4";
+          liveFoldersFile = "${cfg.profilesPath}/${profile.path}/zen-live-folders.jsonlz4";
 
           # Only provider config is declared; the browser fills runtime defaults
           # (interval, lastFetched, options) on load.
@@ -181,7 +172,7 @@ in {
             subject = "live folders";
             skipSubject = "live folder";
             stateFile = liveFoldersFile;
-            lockFile = "${profilePath}/${profileName}/.parentlock";
+            lockFile = "${cfg.profilesPath}/${profile.path}/.parentlock";
             slurpfiles = {
               declaredLiveFolders = liveFoldersJsonFile;
             };

--- a/hm-module/session/store.nix
+++ b/hm-module/session/store.nix
@@ -20,15 +20,6 @@
 
   cfg = getAttrFromPath modulePath config;
 
-  linuxConfigPath = "${config.xdg.configHome}/zen";
-  darwinConfigPath = "${config.home.homeDirectory}/Library/Application Support/Zen";
-
-  profilePath = "${(
-    if pkgs.stdenv.isDarwin
-    then "${darwinConfigPath}/Profiles"
-    else linuxConfigPath
-  )}";
-
   mkJsonlz4Updater = import ../lib/state-writer.nix {inherit pkgs lib;};
 
   mkRowsOption = collection:
@@ -89,7 +80,7 @@ in {
     in
       mapAttrs' (
         profileName: profile: let
-          sessionsFile = "${profilePath}/${profileName}/zen-sessions.jsonlz4";
+          sessionsFile = "${cfg.profilesPath}/${profile.path}/zen-sessions.jsonlz4";
 
           spacesJsonFile = pkgs.writeText "zen-declared-spaces-${profileName}.json" (toJSON profile.sessionStore.spaces);
           pinsJsonFile = pkgs.writeText "zen-declared-pins-${profileName}.json" (toJSON profile.sessionStore.tabs);
@@ -210,7 +201,7 @@ in {
             subject = "sessions";
             skipSubject = "spaces/pins";
             stateFile = sessionsFile;
-            lockFile = "${profilePath}/${profileName}/.parentlock";
+            lockFile = "${cfg.profilesPath}/${profile.path}/.parentlock";
             slurpfiles = {
               declaredSpaces = spacesJsonFile;
               declaredPins = pinsJsonFile;

--- a/hm-module/sine.nix
+++ b/hm-module/sine.nix
@@ -14,15 +14,6 @@
   cfg = getAttrFromPath modulePath config;
 
   isSineEnabled = lib.any (profile: profile.sine.enable) (lib.attrValues cfg.profiles);
-
-  linuxConfigPath = "${config.xdg.configHome}/zen";
-  darwinConfigPath = "${config.home.homeDirectory}/Library/Application Support/Zen";
-
-  profilePath = "${(
-    if pkgs.stdenv.isDarwin
-    then "${darwinConfigPath}/Profiles"
-    else linuxConfigPath
-  )}";
 in {
   options = setAttrByPath modulePath {
     profiles = mkOption {
@@ -64,24 +55,24 @@ in {
           '';
       in
         lib.concatMapAttrs (
-          profileName: profile:
+          _: profile:
             if profile.sine.enable
             then {
-              "${profilePath}/${profileName}/chrome/JS" = {
+              "${cfg.profilesPath}/${profile.path}/chrome/JS" = {
                 source = sinePack.manager + "/src";
                 recursive = true;
                 force = true;
               };
-              "${profilePath}/${profileName}/chrome/JS/locales" = {
+              "${cfg.profilesPath}/${profile.path}/chrome/JS/locales" = {
                 source = sinePack.manager + "/locales";
                 recursive = true;
                 force = true;
               };
-              "${profilePath}/${profileName}/chrome/JS/engine.json" = {
+              "${cfg.profilesPath}/${profile.path}/chrome/JS/engine.json" = {
                 source = engineVersionFile;
                 force = true;
               };
-              "${profilePath}/${profileName}/chrome/utils" = {
+              "${cfg.profilesPath}/${profile.path}/chrome/utils" = {
                 source = sinePack.bootloader + "/profile/utils";
                 recursive = true;
                 force = true;
@@ -108,14 +99,14 @@ in {
       mapAttrs'
       (
         profileName: profile: let
-          modsFilePath = "${profilePath}/${profileName}/chrome/sine-mods/mods.json";
+          modsFilePath = "${cfg.profilesPath}/${profile.path}/chrome/sine-mods/mods.json";
 
           updateSineModsScript =
             pkgs.writeShellScript "zen-sine-mods-update-${profileName}"
             ''
               MODS_FILE="${modsFilePath}"
               SINE_MODS="${lib.concatStringsSep " " profile.sine.mods}"
-              BASE_DIR="${profilePath}/${profileName}"
+              BASE_DIR="${cfg.profilesPath}/${profile.path}"
               MANAGED_FILE="$BASE_DIR/zen-sine-mods-nix-managed.json"
 
               mkdir -p "$BASE_DIR/chrome/sine-mods"


### PR DESCRIPTION
State writers (sine, mods, keyboard shortcuts, session store, live folders) built profile directories from the profiles attrset key, so a profile with path overridden got its files written to a directory the browser never reads. Resolve them from cfg.profilesPath and profile.path instead, dropping the per-module darwin/linux path re-derivations that duplicated upstream's profilesPath.