### PR TITLE
feat(hm): add betterfox preset option

### DIFF
--- a/examples/01-basic-home-manager.nix
+++ b/examples/01-basic-home-manager.nix
@@ -23,5 +23,10 @@
       flavor = "Mocha"; # Frappe | Latte | Macchiato | Mocha
       accent = "Mauve"; # Blue, Flamingo, Green, Lavender, Maroon, Mauve, ...
     };
+
+    # Betterfox for Zen (yokoffing/Betterfox zen/user.js, aka BetterZen):
+    # privacy/telemetry/performance prefs applied as mkDefault settings —
+    # any profile `settings` entry wins.
+    profiles.default.presets.betterfox.enable = true;
   };
 }

--- a/hm-module/default.nix
+++ b/hm-module/default.nix
@@ -66,6 +66,7 @@ in {
     (import ./sine.nix {inherit mkSinePack;})
     (import ./default-browser.nix {inherit name;})
     (import ./presets/catppuccin.nix {inherit self;})
+    (import ./presets/betterfox.nix {inherit self;})
   ];
 
   config = mkIf cfg.enable {

--- a/hm-module/presets/betterfox.nix
+++ b/hm-module/presets/betterfox.nix
@@ -1,0 +1,77 @@
+# Betterfox preset (yokoffing/Betterfox zen/user.js aka BetterZen, pinned in
+# sources.json):
+# the Betterfox privacy/performance prefs Zen does not ship by default.
+# The user.js is parsed into the upstream `settings` option as per-pref
+# mkDefault values instead of being appended through extraConfig: extraConfig
+# lands after the settings-generated prefs in user.js, where the last write
+# wins, so raw text would silently override the profile's own `settings`.
+# With mkDefault any profiles.<name>.settings entry beats the preset.
+{self}: {
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (lib) mkDefault mkIf mkOption setAttrByPath types;
+
+  modulePath = [
+    "programs"
+    "zen-browser"
+  ];
+
+  sources = builtins.fromJSON (builtins.readFile "${self}/sources.json");
+
+  betterfox = pkgs.fetchFromGitHub {
+    inherit (sources.addons.betterfox) rev hash;
+    repo = "Betterfox";
+    owner = "yokoffing";
+  };
+
+  # Every active line is `user_pref("<name>", <value>);` with an optional
+  # trailing `//` comment; values are JSON-compatible (string/int/bool).
+  # A user_pref line the full pattern cannot parse throws instead of being
+  # dropped, so an upstream syntax change fails loudly at eval.
+  parseUserJs = file: let
+    prefLine = ''[[:space:]]*user_pref\(.*'';
+    fullLine = ''[[:space:]]*user_pref\("([^"]+)",[[:space:]]*("[^"]*"|-?[0-9]+|true|false)\);[[:space:]]*(//.*)?'';
+
+    toPref = line: let
+      m = builtins.match fullLine line;
+    in
+      if m != null
+      then [(lib.nameValuePair (builtins.elemAt m 0) (builtins.fromJSON (builtins.elemAt m 1)))]
+      else if builtins.match prefLine line != null
+      then throw "presets.betterfox: unparseable user_pref line in zen/user.js: ${line}"
+      else [];
+  in
+    builtins.listToAttrs (lib.concatMap toPref (lib.splitString "\n" (builtins.readFile file)));
+
+  betterfoxPrefs = parseUserJs "${betterfox}/zen/user.js";
+in {
+  options = setAttrByPath modulePath {
+    profiles = mkOption {
+      type = with types;
+        attrsOf (
+          submodule (
+            {config, ...}: {
+              options = {
+                presets.betterfox.enable = mkOption {
+                  type = bool;
+                  default = false;
+                  description = ''
+                    Enable the Betterfox preset (yokoffing/Betterfox `zen/user.js`, aka BetterZen):
+                    Betterfox privacy, telemetry and performance prefs that Zen does
+                    not ship by default. Every pref is applied with `mkDefault`, so
+                    any `settings` entry on the profile overrides the preset.
+                  '';
+                };
+              };
+
+              config = mkIf config.presets.betterfox.enable {
+                settings = lib.mapAttrs (_: mkDefault) betterfoxPrefs;
+              };
+            }
+          )
+        );
+    };
+  };
+}

--- a/sources.json
+++ b/sources.json
@@ -75,6 +75,10 @@
     "catppuccin": {
       "rev": "c855685442c6040c4dda9c8d3ddc7b708de1cbaa",
       "hash": "sha256-5A57Lyctq497SSph7B+ucuEyF1gGVTsuI3zuBItGfg4="
+    },
+    "betterfox": {
+      "rev": "8e415d1633f10fe0192d9c938e4ca2628eeec9f9",
+      "hash": "sha256-nLkaxpbAMifWxx/RJvuaDpjndzKFPTvAO8o9gR47HtU="
     }
   },
   "metadata_for": {


### PR DESCRIPTION
Add profiles.<name>.presets.betterfox.enable, applying yokoffing/Betterfox zen/user.js (BetterZen) pinned in sources.json addons.betterfox. The file is parsed at eval into per-pref mkDefault settings values, so profile settings entries override the preset; extraConfig is not used because it lands after settings in the generated user.js and would win instead. The parser throws on a user_pref line it cannot parse rather than dropping it.