### PR TITLE
feat(hm): add arkenfox preset option

### DIFF
--- a/examples/01-basic-home-manager.nix
+++ b/examples/01-basic-home-manager.nix
@@ -28,5 +28,8 @@
     # privacy/telemetry/performance prefs applied as mkDefault settings —
     # any profile `settings` entry wins.
     profiles.default.presets.betterfox.enable = true;
+
+    # arkenfox for Zen (arkenfox/user.js)
+    profiles.default.presets.arkenfox.enable = true;
   };
 }

--- a/hm-module/default.nix
+++ b/hm-module/default.nix
@@ -67,6 +67,7 @@ in {
     (import ./default-browser.nix {inherit name;})
     (import ./presets/catppuccin.nix {inherit self;})
     (import ./presets/betterfox.nix {inherit self;})
+    (import ./presets/arkenfox.nix {inherit self;})
   ];
 
   config = mkIf cfg.enable {

--- a/hm-module/presets/arkenfox.nix
+++ b/hm-module/presets/arkenfox.nix
@@ -38,12 +38,12 @@
       if m != null
       then [(lib.nameValuePair (builtins.elemAt m 0) (builtins.fromJSON (builtins.elemAt m 1)))]
       else if builtins.match prefLine line != null
-      then throw "presets.arkenfox: unparseable user_pref line in zen/user.js: ${line}"
+      then throw "presets.arkenfox: unparseable user_pref line in user.js: ${line}"
       else [];
   in
     builtins.listToAttrs (lib.concatMap toPref (lib.splitString "\n" (builtins.readFile file)));
 
-  arkenfoxPrefs = parseUserJs "${arkenfox}/zen/user.js";
+  arkenfoxPrefs = parseUserJs "${arkenfox}/user.js";
 in {
   options = setAttrByPath modulePath {
     profiles = mkOption {

--- a/hm-module/presets/arkenfox.nix
+++ b/hm-module/presets/arkenfox.nix
@@ -1,0 +1,73 @@
+# Arkenfox preset (pinned in sources.json):
+# The user.js is parsed into the upstream `settings` option as per-pref
+# mkDefault values instead of being appended through extraConfig: extraConfig
+# lands after the settings-generated prefs in user.js, where the last write
+# wins, so raw text would silently override the profile's own `settings`.
+# With mkDefault any profiles.<name>.settings entry beats the preset.
+{self}: {
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (lib) mkDefault mkIf mkOption setAttrByPath types;
+
+  modulePath = [
+    "programs"
+    "zen-browser"
+  ];
+
+  sources = builtins.fromJSON (builtins.readFile "${self}/sources.json");
+
+  arkenfox = pkgs.fetchFromGitHub {
+    inherit (sources.addons.arkenfox) rev hash;
+    repo = "user.js";
+    owner = "Arkenfox";
+  };
+
+  # Every active line is `user_pref("<name>", <value>);` with an optional
+  # trailing `//` comment; values are JSON-compatible (string/int/bool).
+  # A user_pref line the full pattern cannot parse throws instead of being
+  # dropped, so an upstream syntax change fails loudly at eval.
+  parseUserJs = file: let
+    prefLine = ''[[:space:]]*user_pref\(.*'';
+    fullLine = ''[[:space:]]*user_pref\("([^"]+)",[[:space:]]*("[^"]*"|-?[0-9]+|true|false)\);[[:space:]]*(//.*)?'';
+
+    toPref = line: let
+      m = builtins.match fullLine line;
+    in
+      if m != null
+      then [(lib.nameValuePair (builtins.elemAt m 0) (builtins.fromJSON (builtins.elemAt m 1)))]
+      else if builtins.match prefLine line != null
+      then throw "presets.arkenfox: unparseable user_pref line in zen/user.js: ${line}"
+      else [];
+  in
+    builtins.listToAttrs (lib.concatMap toPref (lib.splitString "\n" (builtins.readFile file)));
+
+  arkenfoxPrefs = parseUserJs "${arkenfox}/zen/user.js";
+in {
+  options = setAttrByPath modulePath {
+    profiles = mkOption {
+      type = with types;
+        attrsOf (
+          submodule (
+            {config, ...}: {
+              options = {
+                presets.arkenfox.enable = mkOption {
+                  type = bool;
+                  default = false;
+                  description = ''
+                    Enable the Arkenfox preset (arkenfox/users.js `zen/user.js`):
+                    Every pref is applied with `mkDefault`, so any `settings` entry on the profile overrides the preset.
+                  '';
+                };
+              };
+
+              config = mkIf config.presets.arkenfox.enable {
+                settings = lib.mapAttrs (_: mkDefault) arkenfoxPrefs;
+              };
+            }
+          )
+        );
+    };
+  };
+}

--- a/sources.json
+++ b/sources.json
@@ -79,6 +79,10 @@
     "betterfox": {
       "rev": "8e415d1633f10fe0192d9c938e4ca2628eeec9f9",
       "hash": "sha256-nLkaxpbAMifWxx/RJvuaDpjndzKFPTvAO8o9gR47HtU="
+    },
+    "arkenfox": {
+      "rev": "8fe9905c35a1025d1e6df69479f7625585fd956d",
+      "hash": "sha256-+76DopMmUBZ5wJi2/BMCjC/nY2C8vXypX8JmBYEDycc="
     }
   },
   "metadata_for": {


### PR DESCRIPTION
Adds the `programs.zen-browser.profiles.<name>.presets.arkenfox.enable` option to apply the  arkenfox `user.js` config