### PR TITLE
fix(docs): resolve docs-options flake root via self.outPath

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
     };
 
     apps = forAllSystems (pkgs: let
-      root = toString ./.;
+      root = self.outPath;
       gen = ./tooling/gen-options.sh;
     in {
       docs-options = {


### PR DESCRIPTION
toString ./. produced a store snapshot distinct from self; the nested nix eval in gen-options.sh read tooling/ from that path, which is not guaranteed realized under flakehub-cache substitution, breaking the Deploy docs workflow.