### PR TITLE
feat(hm): reset preset prefs left in prefs.js when a preset is disabled

### DIFF
--- a/hm-module/default.nix
+++ b/hm-module/default.nix
@@ -69,6 +69,7 @@ in {
     (import ./presets/catppuccin.nix {inherit self;})
     (import ./presets/betterfox.nix {inherit self;})
     (import ./presets/arkenfox.nix {inherit self;})
+    (import ./presets/cleanup.nix)
   ];
 
   config = mkIf cfg.enable {

--- a/hm-module/lib/prefs-cleaner.nix
+++ b/hm-module/lib/prefs-cleaner.nix
@@ -1,0 +1,114 @@
+# Shared cleaner for prefs baked into a profile's prefs.js by a since-
+# disabled preset. Mirrors the state-writer.nix contract (profile-lock
+# running guard, backup/restore) for the browser-owned prefs.js: it only
+# ever deletes a line whose pref name AND value both match what the last
+# generation recorded in the managed map, so a pref the user re-set by
+# hand after disabling a preset is never touched.
+#
+# Managed map (zen-prefs-nix-managed.json, sibling of the mods managed
+# map): `{ "<pref>": <value> }` — the effective values the enabled
+# presets contributed on the previous activation. Diff against the
+# currently declared map, strip stale exact `user_pref("<name>", <json
+# value>);` lines, then rewrite the map to the declared set (or drop it
+# when no preset is enabled).
+{
+  pkgs,
+  lib,
+}: {
+  name,
+  # Message prefix, e.g. "zen-preset-prefs".
+  logPrefix,
+  profileDir,
+  # Zen profile lock; when held (browser running) the cleanup is skipped
+  # entirely — the map must not advance past a cleanup that never ran.
+  lockFile,
+  # Store JSON `{ "<pref>": <value> }` of the prefs currently contributed
+  # by enabled presets ({} when none are).
+  declaredFile,
+}: let
+  jq = lib.getExe pkgs.jq;
+in
+  pkgs.writeShellScript name ''
+    PROFILE_DIR="${profileDir}"
+    PREFS_FILE="$PROFILE_DIR/prefs.js"
+    MANAGED_FILE="$PROFILE_DIR/zen-prefs-nix-managed.json"
+    DECLARED_FILE="${declaredFile}"
+    BACKUP_FILE="$PREFS_FILE.nix-preset-cleanup.bak"
+    LOCK_FILE="${lockFile}"
+
+    PREFS_TMP=""
+
+    cleanup() {
+      [ -n "$PREFS_TMP" ] && rm -f "$PREFS_TMP" "$PREFS_TMP.next"
+    }
+
+    trap cleanup EXIT
+
+    # Profile dir not created yet: nothing was recorded, nothing to clean.
+    [ -d "$PROFILE_DIR" ] || exit 0
+
+    DECLARED_EMPTY="$(${jq} -r 'length == 0' "$DECLARED_FILE")"
+    if [ ! -f "$MANAGED_FILE" ] && [ "$DECLARED_EMPTY" = "true" ]; then
+      exit 0
+    fi
+
+    if "${lib.getExe pkgs.lsof}" "$LOCK_FILE" >/dev/null 2>&1; then
+      echo "${logPrefix}: Zen Browser appears to be running; skipping preset pref cleanup."
+      echo "${logPrefix}: Close Zen Browser and rebuild to apply it."
+      exit 0
+    fi
+
+    # Stale = recorded by the previous generation, no longer declared.
+    # Emitted as `<name>\t<json value>`; tojson matches how Firefox
+    # serializes user_pref values (ints/bools verbatim, strings quoted),
+    # so a mismatch means the value changed outside Nix.
+    if [ -f "$MANAGED_FILE" ] && [ -f "$PREFS_FILE" ]; then
+      STALE="$(${jq} -r --slurpfile decl "$DECLARED_FILE" '
+        to_entries[]
+        | select(.key as $k | $decl[0] | has($k) | not)
+        | "\(.key)\t\(.value | tojson)"' "$MANAGED_FILE" 2>/dev/null)" || STALE=""
+
+      if [ -n "$STALE" ]; then
+        cp "$PREFS_FILE" "$BACKUP_FILE" || {
+          echo "${logPrefix}: Failed to create backup of $PREFS_FILE"
+          exit 1
+        }
+
+        PREFS_TMP="$(mktemp)"
+        cp "$PREFS_FILE" "$PREFS_TMP"
+
+        while IFS="$(printf '\t')" read -r pref value; do
+          [ -n "$pref" ] || continue
+          line="user_pref(\"$pref\", $value);"
+          if grep -qxF "$line" "$PREFS_TMP"; then
+            grep -vxF "$line" "$PREFS_TMP" > "$PREFS_TMP.next" || true
+            mv "$PREFS_TMP.next" "$PREFS_TMP"
+            echo "${logPrefix}: reset '$pref' (left behind by a disabled preset)"
+          elif grep -qF "user_pref(\"$pref\"," "$PREFS_TMP"; then
+            echo "${logPrefix}: '$pref' was changed outside Nix since the preset set it; leaving it as-is"
+          fi
+        done <<EOF
+    $STALE
+    EOF
+
+        mv "$PREFS_TMP" "$PREFS_FILE" || {
+          echo "${logPrefix}: Failed to update $PREFS_FILE, restoring backup"
+          mv "$BACKUP_FILE" "$PREFS_FILE"
+          exit 1
+        }
+        PREFS_TMP=""
+        rm -f "$BACKUP_FILE"
+      fi
+    fi
+
+    # Advance the map to this generation's preset prefs; drop it when no
+    # preset is enabled so the profile carries no dead state. rm first:
+    # the previous map was copied from a read-only store path.
+    rm -f "$MANAGED_FILE"
+    if [ "$DECLARED_EMPTY" != "true" ]; then
+      ${jq} -S . "$DECLARED_FILE" > "$MANAGED_FILE" || {
+        echo "${logPrefix}: Failed to write $MANAGED_FILE"
+        exit 1
+      }
+    fi
+  ''

--- a/hm-module/presets/arkenfox.nix
+++ b/hm-module/presets/arkenfox.nix
@@ -58,12 +58,14 @@ in {
                   description = ''
                     Enable the Arkenfox preset (arkenfox/users.js `zen/user.js`):
                     Every pref is applied with `mkDefault`, so any `settings` entry on the profile overrides the preset.
+                    Disabling the preset resets the prefs it left in prefs.js.
                   '';
                 };
               };
 
               config = mkIf config.presets.arkenfox.enable {
                 settings = lib.mapAttrs (_: mkDefault) arkenfoxPrefs;
+                presets.managedPrefNames = builtins.attrNames arkenfoxPrefs;
               };
             }
           )

--- a/hm-module/presets/betterfox.nix
+++ b/hm-module/presets/betterfox.nix
@@ -62,12 +62,14 @@ in {
                     Betterfox privacy, telemetry and performance prefs that Zen does
                     not ship by default. Every pref is applied with `mkDefault`, so
                     any `settings` entry on the profile overrides the preset.
+                    Disabling the preset resets the prefs it left in prefs.js.
                   '';
                 };
               };
 
               config = mkIf config.presets.betterfox.enable {
                 settings = lib.mapAttrs (_: mkDefault) betterfoxPrefs;
+                presets.managedPrefNames = builtins.attrNames betterfoxPrefs;
               };
             }
           )

--- a/hm-module/presets/catppuccin.nix
+++ b/hm-module/presets/catppuccin.nix
@@ -95,6 +95,14 @@ in {
                     else 1
                   );
                 };
+
+                # The chrome/catppuccin symlink and userChrome imports are
+                # home.file-managed and vanish on rebuild; only these two
+                # prefs get baked into prefs.js and need cleanup on disable.
+                presets.managedPrefNames = [
+                  "ui.systemUsesDarkTheme"
+                  "zen.view.window.scheme"
+                ];
               };
             }
           )

--- a/hm-module/presets/cleanup.nix
+++ b/hm-module/presets/cleanup.nix
@@ -1,0 +1,99 @@
+# Preset pref cleanup engine. Presets apply prefs through `settings`,
+# which Firefox bakes into the browser-owned prefs.js on launch; removing
+# a preset stops declaring them but never un-bakes them (the arkenfox
+# `browser.startup.page = 0` stranding session restore, catppuccin's
+# `ui.systemUsesDarkTheme` stranding a global dark theme).
+#
+# Each enabled preset contributes its pref names to the internal
+# `presets.managedPrefNames` bus; this engine records their effective
+# values (final `settings`, so a user override is what gets recorded) in
+# zen-prefs-nix-managed.json and, via the prefs-cleaner factory, resets
+# any recorded pref that is no longer declared. The activation entry runs
+# for every profile unconditionally: the map from the previous generation
+# may exist even when no preset is enabled anymore — that is exactly the
+# case that needs cleaning.
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (lib) getAttrFromPath mkIf mkOption setAttrByPath types;
+
+  modulePath = [
+    "programs"
+    "zen-browser"
+  ];
+
+  cfg = getAttrFromPath modulePath config;
+
+  mkPrefsCleaner = import ../lib/prefs-cleaner.nix {inherit pkgs lib;};
+in {
+  options = setAttrByPath modulePath {
+    profiles = mkOption {
+      type = with types;
+        attrsOf (
+          submodule (
+            {...}: {
+              options = {
+                presets.managedPrefNames = mkOption {
+                  type = listOf str;
+                  default = [];
+                  internal = true;
+                  visible = false;
+                  description = ''
+                    Pref names contributed by enabled presets. Tracked in the
+                    profile's zen-prefs-nix-managed.json so prefs baked into
+                    prefs.js are reset when the preset that set them is
+                    disabled.
+                  '';
+                };
+              };
+            }
+          )
+        );
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.activation = let
+      inherit (lib) filterAttrs genAttrs mapAttrs' nameValuePair unique;
+    in
+      mapAttrs'
+      (
+        profileName: profile: let
+          profileDir = "${cfg.profilesPath}/${profile.path}";
+
+          # Effective values: presets set prefs with mkDefault, so the final
+          # `settings` entry — user override included — is what user.js
+          # writes and therefore what prefs.js will contain.
+          declaredPrefs =
+            filterAttrs (_: v: v != null)
+            (genAttrs
+              (unique profile.presets.managedPrefNames)
+              (n: profile.settings.${n} or null));
+
+          declaredFile =
+            pkgs.writeText
+            "zen-preset-prefs-${profileName}.json"
+            (builtins.toJSON declaredPrefs);
+
+          cleanupScript = mkPrefsCleaner {
+            name = "zen-preset-prefs-cleanup-${profileName}";
+            logPrefix = "zen-preset-prefs";
+            inherit profileDir declaredFile;
+            lockFile = "${profileDir}/.parentlock";
+          };
+        in
+          nameValuePair "zen-preset-prefs-${profileName}" (lib.hm.dag.entryAfter ["writeBoundary"] ''
+            ${cleanupScript}
+            if [[ "$?" -eq 0 ]]; then
+              $VERBOSE_ECHO "zen-preset-prefs: Updated managed preset prefs for profile '${profileName}'"
+            else
+              echo "zen-preset-prefs: Failed to clean up preset prefs for profile '${profileName}'!" >&2
+            fi
+          '')
+      )
+      cfg.profiles;
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -74,6 +74,7 @@
     "default-browser" = ./default-browser.nix;
     "private-desktop-entry" = ./private-desktop-entry.nix;
     "env-vars" = ./env-vars.nix;
+    "preset-cleanup" = ./preset-cleanup.nix;
   };
 in
   pkgs.lib.mapAttrs (name: path: mkGenericTest name path) suites

--- a/tests/preset-cleanup.nix
+++ b/tests/preset-cleanup.nix
@@ -1,0 +1,55 @@
+# Preset pref cleanup engine (hm-module/presets/cleanup.nix): the managed
+# map records preset-contributed prefs, and prefs recorded by a previous
+# generation but no longer declared are stripped from prefs.js — unless
+# their value changed outside Nix. `presets.managedPrefNames` is set
+# directly to simulate an enabled preset without fetching a real one.
+{zen-browser-flake, ...}: {
+  homeModule = {
+    imports = [zen-browser-flake.homeModules.beta];
+
+    programs.zen-browser = {
+      enable = true;
+      profiles.default = {
+        settings."test.nix.managed" = 1;
+        presets.managedPrefNames = ["test.nix.managed"];
+      };
+    };
+  };
+
+  testScript = ''
+    profile = "/home/testuser/.config/zen/default"
+    prefs = profile + "/prefs.js"
+    managed = profile + "/zen-prefs-nix-managed.json"
+
+    # First activation records the declared preset pref.
+    managed_out = machine.succeed(f"cat {managed}")
+    assert '"test.nix.managed": 1' in managed_out, "declared pref not recorded: " + managed_out
+
+    # Simulate a previous generation: the browser baked three preset prefs
+    # into prefs.js; the map recorded them, but ui.systemUsesDarkTheme was
+    # later changed by hand (recorded 5, prefs.js has 1).
+    machine.succeed(f"rm -f {prefs}")
+    for line in [
+        'user_pref("test.nix.managed", 1);',
+        'user_pref("browser.startup.page", 0);',
+        'user_pref("ui.systemUsesDarkTheme", 1);',
+        'user_pref("unrelated.pref", "keep me");',
+    ]:
+        machine.succeed(f"echo '{line}' >> {prefs}")
+    machine.succeed(
+        f"echo '{{\"test.nix.managed\":1,\"browser.startup.page\":0,\"ui.systemUsesDarkTheme\":5}}' > {managed}"
+    )
+
+    machine.succeed("systemctl restart home-manager-testuser.service")
+
+    prefs_out = machine.succeed(f"cat {prefs}")
+    assert "browser.startup.page" not in prefs_out, "stale preset pref survived: " + prefs_out
+    assert 'user_pref("ui.systemUsesDarkTheme", 1);' in prefs_out, "hand-changed pref was removed: " + prefs_out
+    assert 'user_pref("unrelated.pref", "keep me");' in prefs_out, "unrelated pref was touched: " + prefs_out
+    assert 'user_pref("test.nix.managed", 1);' in prefs_out, "still-declared pref was removed: " + prefs_out
+
+    managed_out = machine.succeed(f"cat {managed}")
+    assert "browser.startup.page" not in managed_out, "map kept an undeclared pref: " + managed_out
+    assert '"test.nix.managed": 1' in managed_out, "map lost the declared pref: " + managed_out
+  '';
+}


### PR DESCRIPTION
Presets apply prefs through settings, which Firefox bakes into the browser-owned prefs.js on launch; disabling a preset stopped declaring them but never un-baked them (e.g. arkenfox's browser.startup.page = 0 kept killing session restore after removal).
