### PR TITLE
refactor(hm): extract user.js presets into a shared factory

### DIFF
--- a/hm-module/lib/user-js-preset.nix
+++ b/hm-module/lib/user-js-preset.nix
@@ -1,0 +1,79 @@
+# Factory for user.js-based presets (arkenfox, betterfox): fetches the
+# pinned source (sources.json `addons.<name>`), parses its user.js into
+# per-pref `settings` values and registers the pref names on the
+# `presets.managedPrefNames` bus so the cleanup engine resets them when
+# the preset is disabled.
+#
+# Prefs land in the upstream `settings` option as per-pref mkDefault
+# values instead of being appended through extraConfig: extraConfig lands
+# after the settings-generated prefs in user.js, where the last write
+# wins, so raw text would silently override the profile's own `settings`.
+# With mkDefault any profiles.<name>.settings entry beats the preset.
+{
+  name,
+  owner,
+  repo,
+  userJsPath,
+  description,
+}: {self}: {
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (lib) mkDefault mkIf mkOption setAttrByPath types;
+
+  modulePath = [
+    "programs"
+    "zen-browser"
+  ];
+
+  sources = builtins.fromJSON (builtins.readFile "${self}/sources.json");
+
+  src = pkgs.fetchFromGitHub {
+    inherit (sources.addons.${name}) rev hash;
+    inherit owner repo;
+  };
+
+  # Every active line is `user_pref("<name>", <value>);` with an optional
+  # trailing `//` comment; values are JSON-compatible (string/int/bool).
+  # A user_pref line the full pattern cannot parse throws instead of being
+  # dropped, so an upstream syntax change fails loudly at eval.
+  parseUserJs = file: let
+    prefLine = ''[[:space:]]*user_pref\(.*'';
+    fullLine = ''[[:space:]]*user_pref\("([^"]+)",[[:space:]]*("[^"]*"|-?[0-9]+|true|false)\);[[:space:]]*(//.*)?'';
+
+    toPref = line: let
+      m = builtins.match fullLine line;
+    in
+      if m != null
+      then [(lib.nameValuePair (builtins.elemAt m 0) (builtins.fromJSON (builtins.elemAt m 1)))]
+      else if builtins.match prefLine line != null
+      then throw "presets.${name}: unparseable user_pref line in ${userJsPath}: ${line}"
+      else [];
+  in
+    builtins.listToAttrs (lib.concatMap toPref (lib.splitString "\n" (builtins.readFile file)));
+
+  presetPrefs = parseUserJs "${src}/${userJsPath}";
+in {
+  options = setAttrByPath modulePath {
+    profiles = mkOption {
+      type = with types;
+        attrsOf (
+          submodule (
+            {config, ...}: {
+              options.presets.${name}.enable = mkOption {
+                type = bool;
+                default = false;
+                inherit description;
+              };
+
+              config = mkIf config.presets.${name}.enable {
+                settings = lib.mapAttrs (_: mkDefault) presetPrefs;
+                presets.managedPrefNames = builtins.attrNames presetPrefs;
+              };
+            }
+          )
+        );
+    };
+  };
+}

--- a/hm-module/presets/arkenfox.nix
+++ b/hm-module/presets/arkenfox.nix
@@ -1,75 +1,11 @@
-# Arkenfox preset (pinned in sources.json):
-# The user.js is parsed into the upstream `settings` option as per-pref
-# mkDefault values instead of being appended through extraConfig: extraConfig
-# lands after the settings-generated prefs in user.js, where the last write
-# wins, so raw text would silently override the profile's own `settings`.
-# With mkDefault any profiles.<name>.settings entry beats the preset.
-{self}: {
-  pkgs,
-  lib,
-  ...
-}: let
-  inherit (lib) mkDefault mkIf mkOption setAttrByPath types;
-
-  modulePath = [
-    "programs"
-    "zen-browser"
-  ];
-
-  sources = builtins.fromJSON (builtins.readFile "${self}/sources.json");
-
-  arkenfox = pkgs.fetchFromGitHub {
-    inherit (sources.addons.arkenfox) rev hash;
-    repo = "user.js";
-    owner = "Arkenfox";
-  };
-
-  # Every active line is `user_pref("<name>", <value>);` with an optional
-  # trailing `//` comment; values are JSON-compatible (string/int/bool).
-  # A user_pref line the full pattern cannot parse throws instead of being
-  # dropped, so an upstream syntax change fails loudly at eval.
-  parseUserJs = file: let
-    prefLine = ''[[:space:]]*user_pref\(.*'';
-    fullLine = ''[[:space:]]*user_pref\("([^"]+)",[[:space:]]*("[^"]*"|-?[0-9]+|true|false)\);[[:space:]]*(//.*)?'';
-
-    toPref = line: let
-      m = builtins.match fullLine line;
-    in
-      if m != null
-      then [(lib.nameValuePair (builtins.elemAt m 0) (builtins.fromJSON (builtins.elemAt m 1)))]
-      else if builtins.match prefLine line != null
-      then throw "presets.arkenfox: unparseable user_pref line in user.js: ${line}"
-      else [];
-  in
-    builtins.listToAttrs (lib.concatMap toPref (lib.splitString "\n" (builtins.readFile file)));
-
-  arkenfoxPrefs = parseUserJs "${arkenfox}/user.js";
-in {
-  options = setAttrByPath modulePath {
-    profiles = mkOption {
-      type = with types;
-        attrsOf (
-          submodule (
-            {config, ...}: {
-              options = {
-                presets.arkenfox.enable = mkOption {
-                  type = bool;
-                  default = false;
-                  description = ''
-                    Enable the Arkenfox preset (arkenfox/users.js `zen/user.js`):
-                    Every pref is applied with `mkDefault`, so any `settings` entry on the profile overrides the preset.
-                    Disabling the preset resets the prefs it left in prefs.js.
-                  '';
-                };
-              };
-
-              config = mkIf config.presets.arkenfox.enable {
-                settings = lib.mapAttrs (_: mkDefault) arkenfoxPrefs;
-                presets.managedPrefNames = builtins.attrNames arkenfoxPrefs;
-              };
-            }
-          )
-        );
-    };
-  };
+import ../lib/user-js-preset.nix {
+  name = "arkenfox";
+  owner = "Arkenfox";
+  repo = "user.js";
+  userJsPath = "user.js";
+  description = ''
+    Enable the Arkenfox preset (arkenfox/user.js):
+    Every pref is applied with `mkDefault`, so any `settings` entry on the profile overrides the preset.
+    Disabling the preset resets the prefs it left in prefs.js.
+  '';
 }

--- a/hm-module/presets/betterfox.nix
+++ b/hm-module/presets/betterfox.nix
@@ -1,79 +1,13 @@
-# Betterfox preset (yokoffing/Betterfox zen/user.js aka BetterZen, pinned in
-# sources.json):
-# the Betterfox privacy/performance prefs Zen does not ship by default.
-# The user.js is parsed into the upstream `settings` option as per-pref
-# mkDefault values instead of being appended through extraConfig: extraConfig
-# lands after the settings-generated prefs in user.js, where the last write
-# wins, so raw text would silently override the profile's own `settings`.
-# With mkDefault any profiles.<name>.settings entry beats the preset.
-{self}: {
-  pkgs,
-  lib,
-  ...
-}: let
-  inherit (lib) mkDefault mkIf mkOption setAttrByPath types;
-
-  modulePath = [
-    "programs"
-    "zen-browser"
-  ];
-
-  sources = builtins.fromJSON (builtins.readFile "${self}/sources.json");
-
-  betterfox = pkgs.fetchFromGitHub {
-    inherit (sources.addons.betterfox) rev hash;
-    repo = "Betterfox";
-    owner = "yokoffing";
-  };
-
-  # Every active line is `user_pref("<name>", <value>);` with an optional
-  # trailing `//` comment; values are JSON-compatible (string/int/bool).
-  # A user_pref line the full pattern cannot parse throws instead of being
-  # dropped, so an upstream syntax change fails loudly at eval.
-  parseUserJs = file: let
-    prefLine = ''[[:space:]]*user_pref\(.*'';
-    fullLine = ''[[:space:]]*user_pref\("([^"]+)",[[:space:]]*("[^"]*"|-?[0-9]+|true|false)\);[[:space:]]*(//.*)?'';
-
-    toPref = line: let
-      m = builtins.match fullLine line;
-    in
-      if m != null
-      then [(lib.nameValuePair (builtins.elemAt m 0) (builtins.fromJSON (builtins.elemAt m 1)))]
-      else if builtins.match prefLine line != null
-      then throw "presets.betterfox: unparseable user_pref line in zen/user.js: ${line}"
-      else [];
-  in
-    builtins.listToAttrs (lib.concatMap toPref (lib.splitString "\n" (builtins.readFile file)));
-
-  betterfoxPrefs = parseUserJs "${betterfox}/zen/user.js";
-in {
-  options = setAttrByPath modulePath {
-    profiles = mkOption {
-      type = with types;
-        attrsOf (
-          submodule (
-            {config, ...}: {
-              options = {
-                presets.betterfox.enable = mkOption {
-                  type = bool;
-                  default = false;
-                  description = ''
-                    Enable the Betterfox preset (yokoffing/Betterfox `zen/user.js`, aka BetterZen):
-                    Betterfox privacy, telemetry and performance prefs that Zen does
-                    not ship by default. Every pref is applied with `mkDefault`, so
-                    any `settings` entry on the profile overrides the preset.
-                    Disabling the preset resets the prefs it left in prefs.js.
-                  '';
-                };
-              };
-
-              config = mkIf config.presets.betterfox.enable {
-                settings = lib.mapAttrs (_: mkDefault) betterfoxPrefs;
-                presets.managedPrefNames = builtins.attrNames betterfoxPrefs;
-              };
-            }
-          )
-        );
-    };
-  };
+import ../lib/user-js-preset.nix {
+  name = "betterfox";
+  owner = "yokoffing";
+  repo = "Betterfox";
+  userJsPath = "zen/user.js";
+  description = ''
+    Enable the Betterfox preset (yokoffing/Betterfox `zen/user.js`, aka BetterZen):
+    Betterfox privacy, telemetry and performance prefs that Zen does
+    not ship by default. Every pref is applied with `mkDefault`, so
+    any `settings` entry on the profile overrides the preset.
+    Disabling the preset resets the prefs it left in prefs.js.
+  '';
 }


### PR DESCRIPTION
arkenfox.nix and betterfox.nix duplicated the whole module shape: fetchFromGitHub of the pinned source, the user_pref parser, the profiles submodule scaffold, the mkDefault settings mapping and the managedPrefNames wiring. Move all of it into
hm-module/lib/user-js-preset.nix, parameterized by name, owner, repo, userJsPath and description; both presets become ~12-line instantiations. The factory sets presets.managedPrefNames itself, so a future user.js preset cannot ship without disable cleanup. catppuccin stays hand-written: its mechanics (chrome symlink, flavor/accent options, userChrome imports) share nothing with the user.js shape.