### PR TITLE
refactor(hm): merge per-module activation entries into one per-profile runner

### DIFF
--- a/hm-module/activation.nix
+++ b/hm-module/activation.nix
@@ -1,0 +1,83 @@
+# Single per-profile activation entry. Modules contribute ordered
+# fragments to the internal `activationFragments` bus instead of
+# registering their own home.activation entries; the runner declared
+# here executes them under one "zen-browser-<profile>" entry, doing the
+# browser-running profile-lock check once for all fragments that need
+# it and printing a single consolidated skip message. Fragments with
+# `requiresLock` keep their own inner lock check as a race guard only.
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (lib) getAttrFromPath mkIf mkOption setAttrByPath types;
+
+  modulePath = [
+    "programs"
+    "zen-browser"
+  ];
+
+  cfg = getAttrFromPath modulePath config;
+in {
+  options = setAttrByPath modulePath {
+    activationFragments = mkOption {
+      type = with types;
+        attrsOf (listOf (submodule {
+          options = {
+            priority = mkOption {
+              type = int;
+              default = 100;
+              description = "Run order within the profile's entry (lower first).";
+            };
+            requiresLock = mkOption {
+              type = bool;
+              default = false;
+              description = "Skip this fragment when the profile lock is held.";
+            };
+            skipSubject = mkOption {
+              type = nullOr str;
+              default = null;
+              description = "Noun listed in the consolidated browser-running skip message.";
+            };
+            text = mkOption {
+              type = lines;
+              description = "Shell fragment run inside the profile's activation entry.";
+            };
+          };
+        }));
+      internal = true;
+      visible = false;
+      default = {};
+      description = "Activation fragments keyed by profile name.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.activation = let
+      inherit (builtins) concatStringsSep filter map;
+      inherit (lib) concatMapStringsSep filterAttrs mapAttrs' nameValuePair optionalString sort unique;
+    in
+      mapAttrs' (
+        profileName: fragments: let
+          sorted = sort (a: b: a.priority < b.priority) fragments;
+          unguarded = filter (f: !f.requiresLock) sorted;
+          guarded = filter (f: f.requiresLock) sorted;
+          skipSubjects = concatStringsSep ", " (unique (filter (s: s != null) (map (f: f.skipSubject) guarded)));
+          lockFile = "${cfg.profilesPath}/${cfg.profiles.${profileName}.path}/.parentlock";
+        in
+          nameValuePair "zen-browser-${profileName}" (lib.hm.dag.entryAfter ["writeBoundary"] ''
+            ${concatMapStringsSep "\n" (f: f.text) unguarded}
+            ${optionalString (guarded != []) ''
+              if ${lib.getExe pkgs.lsof} "${lockFile}" >/dev/null 2>&1; then
+                echo "zen-browser: Zen Browser appears to be running; skipped: ${skipSubjects}."
+                echo "zen-browser: Close Zen Browser and rebuild to apply those changes."
+              else
+                ${concatMapStringsSep "\n" (f: f.text) guarded}
+              fi
+            ''}
+          '')
+      )
+      (filterAttrs (_: fragments: fragments != []) cfg.activationFragments);
+  };
+}

--- a/hm-module/default.nix
+++ b/hm-module/default.nix
@@ -56,6 +56,7 @@ in {
       };
     })
     (import ./package.nix {inherit self name mkSinePack;})
+    (import ./activation.nix)
     (import ./session/store.nix)
     (import ./session/spaces.nix)
     (import ./session/pins.nix)

--- a/hm-module/keyboard-shortcuts.nix
+++ b/hm-module/keyboard-shortcuts.nix
@@ -107,7 +107,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.activation = let
+    programs.zen-browser.activationFragments = let
       inherit (builtins) toJSON;
       inherit
         (lib)
@@ -229,14 +229,18 @@ in {
             fi
           '';
         in
-          nameValuePair "zen-keyboard-shortcuts-${profileName}" (lib.hm.dag.entryAfter ["writeBoundary"] ''
-            ${updateScript}
-            if [[ "$?" -eq 0 ]]; then
-              $VERBOSE_ECHO "zen-keyboard-shortcuts: Updated keyboard shortcuts for profile '${profileName}'"
-            else
-              echo "zen-keyboard-shortcuts: Failed to update keyboard shortcuts for profile '${profileName}'!" >&2
-            fi
-          '')
+          nameValuePair profileName [
+            {
+              text = ''
+                ${updateScript}
+                if [[ "$?" -eq 0 ]]; then
+                  $VERBOSE_ECHO "zen-keyboard-shortcuts: Updated keyboard shortcuts for profile '${profileName}'"
+                else
+                  echo "zen-keyboard-shortcuts: Failed to update keyboard shortcuts for profile '${profileName}'!" >&2
+                fi
+              '';
+            }
+          ]
       )
       profilesWithShortcuts;
   };

--- a/hm-module/mods.nix
+++ b/hm-module/mods.nix
@@ -33,7 +33,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.activation = let
+    programs.zen-browser.activationFragments = let
       inherit
         (lib)
         filterAttrs
@@ -146,14 +146,18 @@ in {
                         fi
             '';
         in
-          nameValuePair "zen-mods-${profileName}" (lib.hm.dag.entryAfter ["writeBoundary"] ''
-            ${updateModsScript}
-            if [[ "$?" -eq 0 ]]; then
-              $VERBOSE_ECHO "zen-mods: Updated mods for profile '${profileName}'"
-            else
-              echo "zen-mods: Failed to update mods for profile '${profileName}'!" >&2
-            fi
-          '')
+          nameValuePair profileName [
+            {
+              text = ''
+                ${updateModsScript}
+                if [[ "$?" -eq 0 ]]; then
+                  $VERBOSE_ECHO "zen-mods: Updated mods for profile '${profileName}'"
+                else
+                  echo "zen-mods: Failed to update mods for profile '${profileName}'!" >&2
+                fi
+              '';
+            }
+          ]
       )
       profilesWithMods;
   };

--- a/hm-module/presets/cleanup.nix
+++ b/hm-module/presets/cleanup.nix
@@ -56,7 +56,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.activation = let
+    programs.zen-browser.activationFragments = let
       inherit (lib) filterAttrs genAttrs mapAttrs' nameValuePair unique;
     in
       mapAttrs'
@@ -85,14 +85,21 @@ in {
             lockFile = "${profileDir}/.parentlock";
           };
         in
-          nameValuePair "zen-preset-prefs-${profileName}" (lib.hm.dag.entryAfter ["writeBoundary"] ''
-            ${cleanupScript}
-            if [[ "$?" -eq 0 ]]; then
-              $VERBOSE_ECHO "zen-preset-prefs: Updated managed preset prefs for profile '${profileName}'"
-            else
-              echo "zen-preset-prefs: Failed to clean up preset prefs for profile '${profileName}'!" >&2
-            fi
-          '')
+          nameValuePair profileName [
+            {
+              priority = 40;
+              requiresLock = true;
+              skipSubject = "preset prefs";
+              text = ''
+                ${cleanupScript}
+                if [[ "$?" -eq 0 ]]; then
+                  $VERBOSE_ECHO "zen-preset-prefs: Updated managed preset prefs for profile '${profileName}'"
+                else
+                  echo "zen-preset-prefs: Failed to clean up preset prefs for profile '${profileName}'!" >&2
+                fi
+              '';
+            }
+          ]
       )
       cfg.profiles;
   };

--- a/hm-module/session/live-folders.nix
+++ b/hm-module/session/live-folders.nix
@@ -100,7 +100,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.activation = let
+    programs.zen-browser.activationFragments = let
       inherit (builtins) toJSON;
       inherit (lib) filterAttrs getExe mapAttrs' mapAttrsToList nameValuePair optionalAttrs;
 
@@ -194,18 +194,25 @@ in {
             '';
           };
         in
-          nameValuePair "zen-live-folders-${profileName}" (lib.hm.dag.entryAfter ["writeBoundary" "zen-sessions-${profileName}"]
-            ''
-              ${updateScript}
-              if [[ "$?" -eq 0 ]]; then
-                $VERBOSE_ECHO "zen-live-folders: Updated live folders for profile '${profileName}'"
-              else
-                YELLOW="\033[1;33m"
-                NC="\033[0m"
-                echo -e "zen-live-folders:''${YELLOW} Failed to update zen-live-folders.jsonlz4 for Zen browser \"${profileName}\" profile.''${NC}"
-                echo -e "zen-live-folders:''${YELLOW} If Zen Browser was open, close it and rebuild to apply changes.''${NC}"
-              fi
-            '')
+          nameValuePair profileName [
+            {
+              # After zen-sessions: live folders need their session folder rows.
+              priority = 20;
+              requiresLock = true;
+              skipSubject = "live folders";
+              text = ''
+                ${updateScript}
+                if [[ "$?" -eq 0 ]]; then
+                  $VERBOSE_ECHO "zen-live-folders: Updated live folders for profile '${profileName}'"
+                else
+                  YELLOW="\033[1;33m"
+                  NC="\033[0m"
+                  echo -e "zen-live-folders:''${YELLOW} Failed to update zen-live-folders.jsonlz4 for Zen browser \"${profileName}\" profile.''${NC}"
+                  echo -e "zen-live-folders:''${YELLOW} If Zen Browser was open, close it and rebuild to apply changes.''${NC}"
+                fi
+              '';
+            }
+          ]
       )
       profilesWithLiveFolders;
   };

--- a/hm-module/session/space-routing.nix
+++ b/hm-module/session/space-routing.nix
@@ -60,7 +60,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.activation = let
+    programs.zen-browser.activationFragments = let
       inherit (builtins) toJSON;
       inherit (lib) attrValues boolToString filterAttrs getExe mapAttrs' nameValuePair;
 
@@ -140,18 +140,24 @@ in {
             '';
           };
         in
-          nameValuePair "zen-space-routing-${profileName}" (lib.hm.dag.entryAfter ["writeBoundary"]
-            ''
-              ${updateScript}
-              if [[ "$?" -eq 0 ]]; then
-                $VERBOSE_ECHO "zen-space-routing: Updated space routing for profile '${profileName}'"
-              else
-                YELLOW="\033[1;33m"
-                NC="\033[0m"
-                echo -e "zen-space-routing:''${YELLOW} Failed to update zen-space-routing.jsonlz4 for Zen browser \"${profileName}\" profile.''${NC}"
-                echo -e "zen-space-routing:''${YELLOW} If Zen Browser was open, close it and rebuild to apply changes.''${NC}"
-              fi
-            '')
+          nameValuePair profileName [
+            {
+              priority = 30;
+              requiresLock = true;
+              skipSubject = "space routing";
+              text = ''
+                ${updateScript}
+                if [[ "$?" -eq 0 ]]; then
+                  $VERBOSE_ECHO "zen-space-routing: Updated space routing for profile '${profileName}'"
+                else
+                  YELLOW="\033[1;33m"
+                  NC="\033[0m"
+                  echo -e "zen-space-routing:''${YELLOW} Failed to update zen-space-routing.jsonlz4 for Zen browser \"${profileName}\" profile.''${NC}"
+                  echo -e "zen-space-routing:''${YELLOW} If Zen Browser was open, close it and rebuild to apply changes.''${NC}"
+                fi
+              '';
+            }
+          ]
       )
       profilesWithRouting;
   };

--- a/hm-module/session/store.nix
+++ b/hm-module/session/store.nix
@@ -61,7 +61,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    home.activation = let
+    programs.zen-browser.activationFragments = let
       inherit (builtins) toJSON;
       inherit (lib) filterAttrs mapAttrs' nameValuePair optionalString;
 
@@ -219,18 +219,24 @@ in {
             '';
           };
         in
-          nameValuePair "zen-sessions-${profileName}" (lib.hm.dag.entryAfter ["writeBoundary"]
-            ''
-              ${updateScript}
-              if [[ "$?" -eq 0 ]]; then
-                $VERBOSE_ECHO "zen-sessions: Updated spaces/pins for profile '${profileName}'"
-              else
-                YELLOW="\033[1;33m"
-                NC="\033[0m"
-                echo -e "zen-sessions:''${YELLOW} Failed to update zen-sessions.jsonlz4 for Zen browser \"${profileName}\" profile.''${NC}"
-                echo -e "zen-sessions:''${YELLOW} If Zen Browser was open, close it and rebuild to apply changes.''${NC}"
-              fi
-            '')
+          nameValuePair profileName [
+            {
+              priority = 10;
+              requiresLock = true;
+              skipSubject = "spaces/pins";
+              text = ''
+                ${updateScript}
+                if [[ "$?" -eq 0 ]]; then
+                  $VERBOSE_ECHO "zen-sessions: Updated spaces/pins for profile '${profileName}'"
+                else
+                  YELLOW="\033[1;33m"
+                  NC="\033[0m"
+                  echo -e "zen-sessions:''${YELLOW} Failed to update zen-sessions.jsonlz4 for Zen browser \"${profileName}\" profile.''${NC}"
+                  echo -e "zen-sessions:''${YELLOW} If Zen Browser was open, close it and rebuild to apply changes.''${NC}"
+                fi
+              '';
+            }
+          ]
       )
       profilesWithSessionData;
   };

--- a/hm-module/sine.nix
+++ b/hm-module/sine.nix
@@ -83,7 +83,7 @@ in {
         cfg.profiles
       else {};
 
-    home.activation = let
+    programs.zen-browser.activationFragments = let
       inherit
         (lib)
         filterAttrs
@@ -246,15 +246,18 @@ in {
               fi
             '';
         in
-          nameValuePair "zen-sine-mods-${profileName}" (lib.hm.dag.entryAfter ["writeBoundary"]
-            ''
-              ${updateSineModsScript}
-              if [[ "$?" -eq 0 ]]; then
-                $VERBOSE_ECHO "zen-sine-mods: Updated sine mods for profile '${profileName}'"
-              else
-                echo "zen-sine-mods: Failed to update sine mods for profile '${profileName}'!" >&2
-              fi
-            '')
+          nameValuePair profileName [
+            {
+              text = ''
+                ${updateSineModsScript}
+                if [[ "$?" -eq 0 ]]; then
+                  $VERBOSE_ECHO "zen-sine-mods: Updated sine mods for profile '${profileName}'"
+                else
+                  echo "zen-sine-mods: Failed to update sine mods for profile '${profileName}'!" >&2
+                fi
+              '';
+            }
+          ]
       )
       profilesWithSineMods;
   };


### PR DESCRIPTION
## What

`home-manager switch` printed 6–7 `Activating zen-*-<profile>` lines per profile, and with Zen open each of the four lock-guarded state writers printed its own 2-line "browser running, skipping" message (8 lines total).

This adds an internal `activationFragments` bus (`hm-module/activation.nix`) — same idiom as the `sessionStore` rows bus — plus a runner that emits a **single** `home.activation."zen-browser-<profile>"` entry per profile:

1. Unguarded fragments (keyboard-shortcuts, mods, sine) run first.
2. One `lsof .parentlock` check for all guarded fragments.
3. Guarded writers run in priority order (sessions 10 → live-folders 20 → space-routing 30 → preset-prefs 40), or one consolidated 2-line skip message is printed.

Output with Zen open is now:

```
Activating zen-browser-default
zen-browser: Zen Browser appears to be running; skipped: spaces/pins, live folders, space routing, preset prefs.
zen-browser: Close Zen Browser and rebuild to apply those changes.
```

Script bodies are untouched; only registration moved. Inner lock checks in `state-writer.nix`/`prefs-cleaner.nix` stay as race guards for a browser starting mid-activation.

## Breaking

The per-module DAG entry names (`zen-sessions-<profile>`, `zen-mods-<profile>`, …) no longer exist. External configs using `lib.hm.dag.entryAfter` against them lose that ordering silently (home-manager ignores missing DAG targets) and must target `zen-browser-<profile>` instead.

## Notes

- A separate top-level bus option is required: filtering `profiles.<name>` keys by profile values would make attr names depend on attr values of the same option (infinite recursion).
- Cosmetic: the skip message lists "preset prefs" whenever Zen is running even if there was nothing to clean, and the sessions "file not found; created on first run" note is deferred to the next closed-browser rebuild.

## Tests

- `nix flake check`: all VM tests green (sessions, pins, joined-tabs, space-routing, live-folders, preset-cleanup, env-vars, default-browser, private-desktop-entry).
- alejandra + deadnix clean.
- Generated `activate` script inspected for single- and multi-fragment shapes.