### PR TITLE
fix(hm-module): set github icon for github live folders

### DIFF
--- a/hm-module/session/live-folders.nix
+++ b/hm-module/session/live-folders.nix
@@ -68,9 +68,11 @@ in {
                     };
                     emptyTabIds = ["${lf.id}-empty"];
                     userIcon =
-                      if lf.folderIcon == null
-                      then ""
-                      else lf.folderIcon;
+                      if lf.folderIcon != null
+                      then lf.folderIcon
+                      else if lib.hasPrefix "github:" lf.kind
+                      then "chrome://browser/skin/zen-icons/selectable/logo-github.svg"
+                      else "";
                     workspaceId =
                       if lf.workspace == null
                       then null


### PR DESCRIPTION
This adds a fallback icon for GitHub live folders. Current behavior is setting default icon for folders, and live folders

Fixes #359 