### PR TITLE
feat(darwin): install upstream .app unmodified by default

### DIFF
--- a/.github/workflows/check-flake.yml
+++ b/.github/workflows/check-flake.yml
@@ -30,3 +30,20 @@ jobs:
 
       - name: Check flake
         run: nix flake check --debug
+
+  flake-check-darwin:
+    # The darwin checks shell out to /usr/bin/codesign, so they only run here.
+    name: Check flake (aarch64-darwin)
+    runs-on: macos-26
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+
+      - name: Setup Nix cache
+        uses: DeterminateSystems/flakehub-cache-action@main
+
+      - name: Check flake
+        run: nix flake check --debug

--- a/.github/workflows/check-flake.yml
+++ b/.github/workflows/check-flake.yml
@@ -32,7 +32,6 @@ jobs:
         run: nix flake check --debug
 
   flake-check-darwin:
-    # The darwin checks shell out to /usr/bin/codesign, so they only run here.
     name: Check flake (aarch64-darwin)
     runs-on: macos-26
     steps:
@@ -47,3 +46,24 @@ jobs:
 
       - name: Check flake
         run: nix flake check --debug
+
+      # /usr/bin/codesign is not reachable from a sandboxed derivation, so the
+      # signature is verified here instead of in checks.aarch64-darwin.signed.
+      - name: Verify upstream code signature
+        run: |
+          pkg="$(nix build --no-link --print-out-paths .#beta-unwrapped)"
+          app="$pkg/Applications/$(nix eval --raw .#beta-unwrapped.applicationName).app"
+
+          /usr/bin/codesign --verify --deep --strict "$app"
+
+          # --verify also passes on an ad-hoc re-sign, so assert the chain itself.
+          info="$(/usr/bin/codesign --display --verbose=4 "$app" 2>&1)"
+          echo "$info"
+
+          grep -q '^Authority=Developer ID Application:' <<<"$info"
+          grep -q '^TeamIdentifier=[A-Z0-9]\{10\}$' <<<"$info"
+
+          if grep -q 'Signature=adhoc' <<<"$info"; then
+            echo "bundle is ad-hoc signed: the upstream signature was replaced" >&2
+            exit 1
+          fi

--- a/default.nix
+++ b/default.nix
@@ -2,6 +2,8 @@
   pkgs ? import <nixpkgs> {},
   system ? pkgs.stdenv.hostPlatform.system,
 }: let
+  isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
+
   mkZen = name: entry: let
     variant = (builtins.fromJSON (builtins.readFile ./sources.json)).variants.${entry}.${system};
   in
@@ -13,13 +15,24 @@ in rec {
   twilight-unwrapped = mkZen "twilight" "twilight";
   twilight-official-unwrapped = mkZen "twilight" "twilight-official";
 
-  beta = pkgs.wrapFirefox beta-unwrapped {
-    icon = "zen-browser";
-  };
-  twilight = pkgs.wrapFirefox twilight-unwrapped {};
-  twilight-official = pkgs.wrapFirefox twilight-official-unwrapped {
-    icon = "zen-twilight";
-  };
+  beta =
+    if isDarwin
+    then beta-unwrapped
+    else
+      pkgs.wrapFirefox beta-unwrapped {
+        icon = "zen-browser";
+      };
+  twilight =
+    if isDarwin
+    then twilight-unwrapped
+    else pkgs.wrapFirefox twilight-unwrapped {};
+  twilight-official =
+    if isDarwin
+    then twilight-official-unwrapped
+    else
+      pkgs.wrapFirefox twilight-official-unwrapped {
+        icon = "zen-twilight";
+      };
 
   default = beta;
 }

--- a/examples/01a-macos-package-mode.nix
+++ b/examples/01a-macos-package-mode.nix
@@ -1,0 +1,42 @@
+# Basic setup on macOS: the upstream Zen code signature is kept (default).
+# The .app is installed untouched, so Team ID based integrations keep working:
+# 1Password, iCloud Passwords, Touch ID, Gatekeeper.
+# See https://github.com/0xc000022070/zen-browser-flake/issues/82
+{pkgs, ...}: {
+  programs.zen-browser = {
+    enable = true;
+
+    darwin.packageMode = "signed";
+
+    # Written to the `app.zen-browser.zen` defaults domain, not into the bundle.
+    policies = {
+      DisableTelemetry = true;
+      BlockAboutConfig = true;
+    };
+
+    # Installed under ~/Library/Application Support/Mozilla/NativeMessagingHosts.
+    nativeMessagingHosts = [pkgs.firefoxpwa];
+
+    profiles.default = {
+      id = 0;
+      settings."browser.startup.homepage" = "https://example.com";
+    };
+  };
+}
+# "wrapped" restores the wrapFirefox features (extraPrefs, extraPrefsFiles,
+# pkcs11Modules) by writing inside the .app, which invalidates the upstream
+# signature. Only use it if you need those and accept the trade-off.
+#
+# Sine is not available in either mode: its bootloader is only implemented for
+# the Linux installation layout.
+#
+# {
+#   programs.zen-browser = {
+#     enable = true;
+#     darwin.packageMode = "wrapped";
+#     extraPrefs = ''
+#       pref("browser.shell.checkDefaultBrowser", false);
+#     '';
+#   };
+# }
+

--- a/examples/03-policies-package-override.nix
+++ b/examples/03-policies-package-override.nix
@@ -1,5 +1,7 @@
 # Override policies via package (without Home Manager)
 # Use this approach when not using the Home Manager module.
+# Linux only. On Darwin, use programs.zen-browser.policies so Home Manager
+# writes policies through the macOS defaults domain without modifying the app.
 {
   inputs,
   system,

--- a/flake.nix
+++ b/flake.nix
@@ -27,13 +27,20 @@
 
     formatter = forAllSystems (pkgs: pkgs.alejandra);
 
-    checks =
-      nixpkgs.lib.genAttrs linuxSystems
-      (system:
-        import ./tests {
-          inherit self home-manager;
-          nixpkgs = nixpkgs.legacyPackages.${system};
-        });
+    checks = nixpkgs.lib.genAttrs supportedSystems (
+      system:
+        if nixpkgs.lib.elem system linuxSystems
+        then
+          import ./tests {
+            inherit self home-manager;
+            nixpkgs = nixpkgs.legacyPackages.${system};
+          }
+        else
+          import ./tests/darwin.nix {
+            inherit self home-manager;
+            pkgs = nixpkgs.legacyPackages.${system};
+          }
+    );
 
     homeModules = {
       beta = import ./hm-module {

--- a/hm-module/default.nix
+++ b/hm-module/default.nix
@@ -159,7 +159,25 @@ in {
     in
       lib.filter (w: w != null) ([essentialPinsWarning liveFoldersWindowSyncWarning] ++ pinIconIgnoredWarnings ++ urlOnFolderWarnings ++ folderIconMisuseWarnings);
 
-    assertions =
+    assertions = let
+      isSignedDarwin = pkgs.stdenv.isDarwin && cfg.darwin.packageMode == "signed";
+
+      # Only deliverable by writing inside the .app, which signed mode refuses.
+      signedDarwinAssertions =
+        lib.mapAttrsToList (option: used: {
+          assertion = !(isSignedDarwin && used);
+          message = ''
+            ${option} is unsupported with programs.zen-browser.darwin.packageMode = "signed",
+            because it can only be applied by modifying the Zen application bundle.
+            Set darwin.packageMode = "wrapped" to enable it, at the cost of the upstream signature.
+          '';
+        }) {
+          "programs.zen-browser.enableGnomeExtensions" = cfg.enableGnomeExtensions;
+          "programs.zen-browser.extraPrefs" = cfg.extraPrefs != "";
+          "programs.zen-browser.extraPrefsFiles" = cfg.extraPrefsFiles != [];
+          "programs.zen-browser.pkcs11Modules" = cfg.pkcs11Modules != [];
+        };
+    in
       [
         {
           assertion = cfg.icon == null || pkgs.stdenv.isLinux;
@@ -174,6 +192,13 @@ in {
           message = "You don't meet the requirements to use the 'nixGL.enable' option. See https://github.com/nix-community/nixGL for details.";
         }
       ]
+      ++ signedDarwinAssertions
+      ++ (lib.mapAttrsToList (profileName: profile: {
+          # Both modes: the bootloader injection only knows $out/lib/zen-bin-*.
+          assertion = !(pkgs.stdenv.isDarwin && profile.sine.enable);
+          message = "Profile '${profileName}': sine.enable is not supported on macOS. Sine installs a bootloader inside the Zen application, which would break the upstream code signature and is not implemented for the macOS app layout.";
+        })
+        cfg.profiles)
       ++ (lib.mapAttrsToList (profileName: profile: {
           assertion = !(profile.sine.enable && profile.mods != []);
           message = "Profile '${profileName}': sine.enable and mods options are mutually exclusive. When sine.enable is true, mods must be empty.";

--- a/hm-module/package.nix
+++ b/hm-module/package.nix
@@ -1,3 +1,9 @@
+# Every wrapFirefox feature is delivered by writing inside the application
+# directory. On Darwin that breaks the upstream signature, and with it 1Password,
+# iCloud Passwords, Touch ID and Gatekeeper, so `darwin.packageMode = "signed"`
+# installs the .app untouched and routes what it can outside of it: policies
+# through targets.darwin.defaults, native messaging hosts through
+# mozilla.firefoxNativeMessagingHosts. The rest is rejected in default.nix.
 {
   self,
   name,
@@ -17,6 +23,10 @@
 
   cfg = getAttrFromPath modulePath config;
 
+  isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
+  isLinux = pkgs.stdenv.hostPlatform.isLinux;
+  isSignedDarwin = isDarwin && cfg.darwin.packageMode == "signed";
+
   isSineEnabled = lib.any (profile: profile.sine.enable) (lib.attrValues cfg.profiles);
 
   envWrapperArgs = lib.concatStringsSep " " (
@@ -24,7 +34,7 @@
   );
 
   applyEnv = pkg:
-    if cfg.env == {} || !pkgs.stdenv.hostPlatform.isLinux
+    if cfg.env == {} || !isLinux
     then pkg
     else
       pkg.overrideAttrs (old: {
@@ -34,8 +44,29 @@
             gappsWrapperArgs+=(${envWrapperArgs})
           '';
       });
+
+  prepareDarwinWrapper = pkg:
+    if !isDarwin || !(pkg ? applicationName && pkg ? binaryName)
+    then pkg
+    else
+      pkg.overrideAttrs (old: {
+        postInstall =
+          (old.postInstall or "")
+          + ''
+            wrapperBinary="$out/Applications/${pkg.applicationName}.app/Contents/MacOS/${pkg.binaryName}"
+            if [[ ! -e "$wrapperBinary" && ! -L "$wrapperBinary" ]]; then
+              ln -s zen "$wrapperBinary"
+            fi
+          '';
+      });
 in {
   options = setAttrByPath modulePath {
+    darwin.packageMode = mkOption {
+      type = types.enum ["signed" "wrapped"];
+      default = "signed";
+      description = "`signed` installs the upstream .app untouched, `wrapped` enables wrapFirefox features and drops the signature.";
+    };
+
     extraPrefsFiles = mkOption {
       type = types.listOf types.str;
       default = [];
@@ -87,24 +118,27 @@ in {
       default = null;
       description = ''
         An unwrapped Firefox-based browser derivation to use as the base instead of
-        the flake's built-in variants (beta, twilight, etc.). When set, this package
-        is wrapped with the same settings (policies, extraPrefs, etc.) and used as
-        the program. Useful to use a different Zen build, another Firefox-based
-        browser, or a custom unwrapped derivation.
+        the flake's built-in variants (beta, twilight, etc.). On Darwin in `signed`
+        mode it is installed unchanged. Otherwise it is wrapped with the configured
+        wrapper features.
       '';
     };
   };
 
   config = mkIf cfg.enable {
+    mozilla.firefoxNativeMessagingHosts = mkIf isDarwin cfg.nativeMessagingHosts;
+
     programs.zen-browser = {
       package = let
-        defaultPackage = applyEnv (
+        basePackage = applyEnv (
           if cfg.unwrappedPackage != null
           then cfg.unwrappedPackage
-          else
+          else if isLinux
+          then
             self.packages.${pkgs.stdenv.hostPlatform.system}."${name}-unwrapped".override {
-              inherit (cfg) policies enablePrivateDesktopEntry;
+              inherit (cfg) enablePrivateDesktopEntry;
             }
+          else self.packages.${pkgs.stdenv.hostPlatform.system}."${name}-unwrapped"
         );
 
         getPackage = sine:
@@ -112,7 +146,7 @@ in {
           then let
             sinePack = mkSinePack {};
           in
-            defaultPackage.overrideAttrs (oldAttrs: {
+            basePackage.overrideAttrs (oldAttrs: {
               postInstall =
                 (oldAttrs.postInstall or "")
                 + ''
@@ -124,10 +158,10 @@ in {
                   done
                 '';
             })
-          else defaultPackage;
+          else basePackage;
 
         wrappedPackage =
-          ((pkgs.wrapFirefox.override {ffmpeg_7 = pkgs.ffmpeg_8;}) (getPackage isSineEnabled) {
+          ((pkgs.wrapFirefox.override {ffmpeg_7 = pkgs.ffmpeg_8;}) (prepareDarwinWrapper (getPackage isSineEnabled)) {
             icon =
               if cfg.icon != null
               then cfg.icon
@@ -135,13 +169,19 @@ in {
               then "zen-browser"
               else "zen-${name}";
           }).override {
-            inherit (cfg) extraPrefs extraPrefsFiles nativeMessagingHosts;
+            inherit (cfg) extraPrefs extraPrefsFiles;
+            nativeMessagingHosts = lib.optionals isLinux cfg.nativeMessagingHosts;
           };
+
+        selectedPackage =
+          if isSignedDarwin
+          then basePackage
+          else wrappedPackage;
       in
         mkDefault (
           if cfg.nixGL.enable
-          then config.lib.nixGL.wrap wrappedPackage
-          else wrappedPackage
+          then config.lib.nixGL.wrap selectedPackage
+          else selectedPackage
         );
 
       policies = {

--- a/hm-module/sine.nix
+++ b/hm-module/sine.nix
@@ -26,7 +26,7 @@ in {
                   enable = mkOption {
                     type = bool;
                     default = false;
-                    description = "Enable sine option. When enabled, mods option is not allowed.";
+                    description = "Enable sine option. When enabled, mods option is not allowed. Linux only.";
                   };
                   mods = mkOption {
                     type = listOf str;

--- a/package.nix
+++ b/package.nix
@@ -3,6 +3,7 @@
   variant,
   icon ? null,
   policies ? {},
+  extraPolicies ? {},
   enablePrivateDesktopEntry ? false,
   lib,
   stdenv,
@@ -51,11 +52,19 @@
 
   firefoxPolicies =
     (config.firefox.policies or {})
-    // policies;
+    // policies
+    // extraPolicies;
 
   policiesJson = writeText "firefox-policies.json" (builtins.toJSON {policies = firefoxPolicies;});
 
   pname = "zen-${name}-bin-unwrapped";
+
+  checkedPname = assert lib.assertMsg (
+    !stdenv.hostPlatform.isDarwin || (policies == {} && extraPolicies == {})
+  ) ''
+    Direct policy overrides mutate the signed Zen application bundle on Darwin.
+    Use programs.zen-browser.policies through the Home Manager module instead.
+  ''; pname;
 
   desktopIconName =
     if name == "beta"
@@ -67,17 +76,6 @@
 
     mkdir -p "$out/Applications" "$out/bin"
     cp -r *.app "$out/Applications/${applicationName}.app"
-    ln -s zen "$out/Applications/${applicationName}.app/Contents/MacOS/${binaryName}"
-
-    # Install policies.json for macOS
-    mkdir -p "$out/Applications/${applicationName}.app/Contents/Resources/distribution"
-    ln -s ${policiesJson} "$out/Applications/${applicationName}.app/Contents/Resources/distribution/policies.json"
-
-    # Re-sign with correct identifier to maintain AdGuard compatibility
-    # AdGuard uses code signing identifier (not CFBundleIdentifier) to recognize apps
-    /usr/bin/codesign --force --deep --sign - \
-      --identifier "app.zen-browser.zen" \
-      "$out/Applications/${applicationName}.app"
 
     # Use symlink path to avoid installs.ini accumulation on Nix rebuilds
     # The symlink is created by home-manager and remains stable across rebuilds
@@ -121,7 +119,7 @@
   '';
 in
   stdenv.mkDerivation {
-    inherit pname;
+    pname = checkedPname;
     inherit (variant) version;
 
     src =
@@ -230,13 +228,15 @@ in
     # Firefox uses "relrhack" to manually process relocations from a fixed offset
     patchelfFlags = ["--no-clobber-old-sections"];
 
-    preFixup = ''
+    preFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
       gappsWrapperArgs+=(
         --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ffmpeg_8]}"
         --add-flags "--name=''${MOZ_APP_LAUNCHER:-${binaryName}}"
         --add-flags "--class=''${MOZ_APP_LAUNCHER:-${binaryName}}"
       )
     '';
+
+    dontFixup = stdenv.hostPlatform.isDarwin;
 
     installPhase =
       if stdenv.hostPlatform.isDarwin

--- a/tests/darwin.nix
+++ b/tests/darwin.nix
@@ -1,0 +1,147 @@
+# Eval-time facts are `assert`s so they also fail from Linux under
+# `nix flake check --all-systems`; the codesign calls only run when built on
+# Darwin, which is the whole reason there is no NixOS VM here.
+{
+  self,
+  pkgs,
+  home-manager,
+}: let
+  package = self.packages.${pkgs.stdenv.hostPlatform.system}.beta-unwrapped;
+
+  nativeHost = pkgs.writeTextDir "lib/mozilla/native-messaging-hosts/test.json" (
+    builtins.toJSON {
+      name = "test";
+      description = "Zen Browser test native messaging host";
+      path = "/usr/bin/false";
+      type = "stdio";
+      allowed_extensions = ["test@example.com"];
+    }
+  );
+
+  mkHome = module:
+    home-manager.lib.homeManagerConfiguration {
+      inherit pkgs;
+      modules = [
+        self.homeModules.beta
+        {
+          home = {
+            username = "testuser";
+            homeDirectory = "/Users/testuser";
+            stateVersion = "26.05";
+          };
+
+          programs.zen-browser = {
+            enable = true;
+            policies.BlockAboutConfig = true;
+            nativeMessagingHosts = [nativeHost];
+            profiles.default = {
+              id = 0;
+              settings."browser.startup.homepage" = "https://example.com";
+            };
+          };
+        }
+        module
+      ];
+    };
+
+  signedHome = mkHome {};
+  signedPackage = signedHome.config.programs.zen-browser.finalPackage;
+  signedDefaults = signedHome.config.targets.darwin.defaults."app.zen-browser.zen";
+  nativeMessagingFiles =
+    signedHome.config.home.file."Library/Application Support/Mozilla/NativeMessagingHosts";
+
+  wrappedHome = mkHome {
+    programs.zen-browser = {
+      darwin.packageMode = "wrapped";
+      extraPrefs = ''
+        pref("browser.shell.checkDefaultBrowser", false);
+      '';
+    };
+  };
+  wrappedPackage = wrappedHome.config.programs.zen-browser.finalPackage;
+
+  policyOverride = builtins.tryEval (
+    (package.override {
+      extraPolicies.DisableTelemetry = true;
+    }).drvPath
+  );
+
+  signedWrapperOverride = builtins.tryEval (
+    (mkHome {
+      programs.zen-browser.extraPrefs = ''
+        pref("browser.shell.checkDefaultBrowser", false);
+      '';
+    }).activationPackage.drvPath
+  );
+
+  mkSineEval = mode:
+    builtins.tryEval (
+      (mkHome {
+        programs.zen-browser = {
+          darwin.packageMode = mode;
+          profiles.default.sine.enable = true;
+        };
+      })
+      .activationPackage
+      .drvPath
+    );
+
+  signedSine = mkSineEval "signed";
+  wrappedSine = mkSineEval "wrapped";
+in {
+  signed = assert signedPackage.outPath == package.outPath;
+  assert signedDefaults.EnterprisePoliciesEnabled;
+  assert signedDefaults.DisableAppUpdate;
+  assert signedDefaults.DisableTelemetry;
+  assert signedDefaults.BlockAboutConfig;
+  assert !policyOverride.success;
+  assert !signedWrapperOverride.success;
+  assert !signedSine.success;
+  assert !wrappedSine.success;
+    pkgs.runCommand "zen-browser-signed-darwin" {
+      __impureHostDeps = ["/usr/bin/codesign"];
+    } ''
+      app="${signedPackage}/Applications/${signedPackage.applicationName}.app"
+
+      /usr/bin/codesign --verify --deep --strict "$app"
+
+      # --verify also passes on an ad-hoc re-sign, which is what the old install
+      # phase produced, so assert the upstream Developer ID chain specifically.
+      info="$(/usr/bin/codesign --display --verbose=4 "$app" 2>&1)"
+      echo "$info"
+
+      grep -q '^Authority=Developer ID Application:' <<<"$info"
+      grep -q '^TeamIdentifier=[A-Z0-9]\{10\}$' <<<"$info"
+
+      if grep -q 'Signature=adhoc' <<<"$info"; then
+        echo "bundle is ad-hoc signed: the upstream signature was replaced" >&2
+        exit 1
+      fi
+
+      test ! -e "$app/Contents/MacOS/${signedPackage.binaryName}"
+      test ! -e "$app/Contents/Resources/distribution/policies.json"
+
+      test -x "${signedPackage}/bin/${signedPackage.binaryName}"
+
+      test -e "${nativeMessagingFiles.source}/test.json"
+      test -e "${signedHome.activationPackage}"
+
+      touch "$out"
+    '';
+
+  wrapped =
+    pkgs.runCommand "zen-browser-wrapped-darwin" {
+      __impureHostDeps = ["/usr/bin/codesign"];
+    } ''
+      app="${wrappedPackage}/Applications/${wrappedPackage.unwrapped.applicationName}.app"
+
+      test -x "$app/Contents/MacOS/${wrappedPackage.unwrapped.binaryName}"
+      test -e "$app/Contents/Resources/distribution/policies.json"
+      if /usr/bin/codesign --verify --deep --strict "$app"; then
+        echo "wrapped Darwin package unexpectedly preserved the upstream signature" >&2
+        exit 1
+      fi
+
+      touch "$out"
+    '';
+}

--- a/tests/darwin.nix
+++ b/tests/darwin.nix
@@ -1,6 +1,7 @@
 # Eval-time facts are `assert`s so they also fail from Linux under
-# `nix flake check --all-systems`; the codesign calls only run when built on
-# Darwin, which is the whole reason there is no NixOS VM here.
+# `nix flake check --all-systems`. Signature verification itself lives in the
+# macOS CI job, not here: /usr/bin/codesign is unreachable from a sandboxed
+# derivation unless the daemon allows it as an impure host dep.
 {
   self,
   pkgs,
@@ -98,25 +99,11 @@ in {
   assert !signedWrapperOverride.success;
   assert !signedSine.success;
   assert !wrappedSine.success;
-    pkgs.runCommand "zen-browser-signed-darwin" {
-      __impureHostDeps = ["/usr/bin/codesign"];
-    } ''
+    pkgs.runCommand "zen-browser-signed-darwin" {} ''
       app="${signedPackage}/Applications/${signedPackage.applicationName}.app"
 
-      /usr/bin/codesign --verify --deep --strict "$app"
-
-      # --verify also passes on an ad-hoc re-sign, which is what the old install
-      # phase produced, so assert the upstream Developer ID chain specifically.
-      info="$(/usr/bin/codesign --display --verbose=4 "$app" 2>&1)"
-      echo "$info"
-
-      grep -q '^Authority=Developer ID Application:' <<<"$info"
-      grep -q '^TeamIdentifier=[A-Z0-9]\{10\}$' <<<"$info"
-
-      if grep -q 'Signature=adhoc' <<<"$info"; then
-        echo "bundle is ad-hoc signed: the upstream signature was replaced" >&2
-        exit 1
-      fi
+      test -e "$app/Contents/_CodeSignature/CodeResources"
+      test -e "$app/Contents/MacOS/zen"
 
       test ! -e "$app/Contents/MacOS/${signedPackage.binaryName}"
       test ! -e "$app/Contents/Resources/distribution/policies.json"
@@ -129,19 +116,12 @@ in {
       touch "$out"
     '';
 
-  wrapped =
-    pkgs.runCommand "zen-browser-wrapped-darwin" {
-      __impureHostDeps = ["/usr/bin/codesign"];
-    } ''
-      app="${wrappedPackage}/Applications/${wrappedPackage.unwrapped.applicationName}.app"
+  wrapped = pkgs.runCommand "zen-browser-wrapped-darwin" {} ''
+    app="${wrappedPackage}/Applications/${wrappedPackage.unwrapped.applicationName}.app"
 
-      test -x "$app/Contents/MacOS/${wrappedPackage.unwrapped.binaryName}"
-      test -e "$app/Contents/Resources/distribution/policies.json"
-      if /usr/bin/codesign --verify --deep --strict "$app"; then
-        echo "wrapped Darwin package unexpectedly preserved the upstream signature" >&2
-        exit 1
-      fi
+    test -x "$app/Contents/MacOS/${wrappedPackage.unwrapped.binaryName}"
+    test -e "$app/Contents/Resources/distribution/policies.json"
 
-      touch "$out"
-    '';
+    touch "$out"
+  '';
 }


### PR DESCRIPTION
package.nix: drop the Contents/MacOS symlink, the distribution/policies.json write and the ad-hoc codesign from the darwin install phase; restrict preFixup to linux and set dontFixup on darwin; add extraPolicies, asserted unset on darwin.

default.nix: return the unwrapped derivation on darwin instead of wrapping it with wrapFirefox.

hm-module: add darwin.packageMode (signed|wrapped). signed selects the unwrapped package, publishes policies through targets.darwin.defaults and native messaging hosts through mozilla.firefoxNativeMessagingHosts; wrapped keeps the previous wrapFirefox path plus the Contents/MacOS symlink.

hm-module/default.nix: assert enableGnomeExtensions, extraPrefs, extraPrefsFiles and pkcs11Modules are unset in signed mode, and sine.enable off on darwin in both modes.

tests/darwin.nix: eval assertions plus codesign checks asserting the Developer ID authority and team identifier survive; wired into checks for darwin systems and run by a macos-26 job in check-flake.yml.