### PR TITLE
docs(examples): add extension storage and managed storage config

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -131,8 +131,8 @@ See the `examples/` directory for standalone configuration examples:
 | [02a-policies-preferences.nix](../examples/02a-policies-preferences.nix)         | Locked preferences (policies.Preferences) |
 | [02b-settings-preferences.nix](../examples/02b-settings-preferences.nix)         | User settings (profiles.\*.settings)      |
 | [03-policies-package-override.nix](../examples/03-policies-package-override.nix) | Package-level policy override             |
-| [04-extensions.nix](../examples/04-extensions.nix)                               | Firefox addons                            |
-| [04b-extensions-rycee.nix](../examples/04b-extensions-rycee.nix)                 | Firefox addons via rycee.nix              |
+| [04-extensions.nix](../examples/04-extensions.nix)                               | Firefox addons, managed storage config    |
+| [04b-extensions-rycee.nix](../examples/04b-extensions-rycee.nix)                 | Firefox addons via rycee.nix, ext storage |
 | [05-mods-installation.nix](../examples/05-mods-installation.nix)                 | Zen theme store mods                      |
 | [06-search-engines.nix](../examples/06-search-engines.nix)                       | Custom search engines                     |
 | [07-bookmarks.nix](../examples/07-bookmarks.nix)                                 | Bookmark organization                     |

--- a/examples/04-extensions.nix
+++ b/examples/04-extensions.nix
@@ -9,6 +9,26 @@
       "wappalyzer@crunchlabz.com" = "wappalyzer";
       "{85860b32-02a8-431a-b2b1-40fbd64c9c69}" = "github-file-icons";
     };
+
+    # Per-extension config via browser.storage.managed, for extensions that
+    # read it — uBlock Origin does (`toOverwrite`, >= 1.33), ClearURLs does not.
+    # Unlike profiles.<name>.extensions.settings (04b) it leaves the extension's
+    # own storage alone, but it is a lock rather than a seed: re-asserted on
+    # every start, so dashboard edits revert. Takes effect one restart late,
+    # uBO caches managed storage on purpose (uAssets discussion 16939).
+    "3rdparty".Extensions."uBlock0@raymondhill.net".toOverwrite = {
+      # Entries matching `scheme://` are also subscribed as external lists.
+      filterLists = [
+        "user-filters"
+        "ublock-filters"
+        "ublock-badware"
+        "ublock-privacy"
+        "ublock-unbreak"
+        "adguard-spyware-url"
+      ];
+      filters = ["||ads.example.org^"]; # dashboard: My filters
+      trustedSiteDirectives = ["example.org"]; # dashboard: Trusted sites
+    };
   };
 }
 # Learn more:

--- a/examples/04b-extensions-rycee.nix
+++ b/examples/04b-extensions-rycee.nix
@@ -5,6 +5,15 @@
 #   url = "gitlab:rycee/nur-expressions?dir=pkgs/firefox-addons";
 #   inputs.nixpkgs.follows = "nixpkgs";
 # };
+#
+# `settings` writes browser-extension-data/<id>/storage.js. Keys are the
+# extension's own storage.local schema, so read its source; declare every key
+# you care about, omitted ones revert to the extension's defaults on each
+# switch. Requires `force`, and sets ExtensionStorageIDB.enabled=false for the
+# whole profile, which drops every extension to the legacy JSON backend and
+# hides what they had in IndexedDB (nix-community/home-manager#9211).
+#
+# Prefer the managed-storage route in 04-extensions.nix where supported.
 {
   inputs,
   pkgs,
@@ -12,10 +21,51 @@
 }: let
   firefox-addons = inputs.firefox-addons.packages.${pkgs.stdenv.hostPlatform.system};
 in {
-  programs.zen-browser.profiles.default.extensions.packages = with firefox-addons; [
-    ublock-origin
-    dearrow
-    proton-pass
-    vimium-ff
-  ];
+  programs.zen-browser.profiles.default.extensions = {
+    packages = with firefox-addons; [
+      ublock-origin
+      clearurls
+      dearrow
+      proton-pass
+      vimium-ff
+    ];
+
+    settings = {
+      # uBlock Origin also accepts managed storage, see 04-extensions.nix.
+      "uBlock0@raymondhill.net" = {
+        force = true;
+        settings.selectedFilterLists = [
+          "user-filters"
+          "ublock-filters"
+          "ublock-badware"
+          "ublock-privacy"
+          "ublock-unbreak"
+        ];
+      };
+
+      # ClearURLs reads no managed storage, this is the only declarative route.
+      # Runtime keys (ClearURLsData, dataHash, log, counters) are left out on
+      # purpose, the extension refetches them.
+      "{74145f27-f039-47ce-a470-a662b129930a}" = {
+        force = true;
+        settings = {
+          badged_color = "#ffa500";
+          badgedStatus = true;
+          contextMenuEnabled = true;
+          domainBlocking = true;
+          eTagFiltering = false;
+          globalStatus = true;
+          hashURL = "https://rules2.clearurls.xyz/rules.minify.hash";
+          historyListenerEnabled = true;
+          localHostsSkipping = true;
+          logLimit = 100;
+          loggingStatus = false;
+          pingBlocking = true;
+          referralMarketing = false;
+          ruleURL = "https://rules2.clearurls.xyz/data.minify.json";
+          statisticsStatus = true;
+        };
+      };
+    };
+  };
 }


### PR DESCRIPTION
Extend 04-extensions.nix with policies."3rdparty".Extensions.<id>.toOverwrite for uBlock Origin filter lists, custom filters and trusted sites.

Extend 04b-extensions-rycee.nix with profiles.<name>.extensions.settings for uBlock Origin and ClearURLs, and add clearurls to packages. The ClearURLs values are its initSettings() defaults from 1.27.3; runtime keys are omitted.

Both options come from mkFirefoxModule and policies passthrough, no module change is involved.

Addresses https://github.com/0xc000022070/zen-browser-flake/issues/332.