### PR TITLE
docs: add space routing to readme examples table

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -146,6 +146,7 @@ See the `examples/` directory for standalone configuration examples:
 | [15-joined-tabs.nix](../examples/15-joined-tabs.nix) | Joined tabs configuration  |                                          |
 | [16-environment-variables](../examples/16-environment-variables.nix) | Environment variables (themes, etc.)                  |
 | [17-live-folders](../examples/17-live-folders.nix) | Live folders (Issues, etc)  |                                           |
+| [18-space-routing](../examples/18-space-routing.nix) | Space routing  |                                           |
 ## Home Manager Reference
 
 This module is based on Home Manager's


### PR DESCRIPTION
This adds the missing 18-space-routing example in README table