### PR TITLE
feat(source): add source-built beta package

### DIFF
--- a/.github/workflows/build-source.yml
+++ b/.github/workflows/build-source.yml
@@ -1,0 +1,36 @@
+name: Build Zen from source
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Build
+        run: |
+          nix build -L .#beta-source
+          nix path-info -S ./result
+          readlink -f ./result > result-path.txt
+
+      - name: Create portable Nix cache
+        run: |
+          mkdir -p zen-cache
+          nix copy \
+            --to "file://$PWD/zen-cache?compression=zstd&compression-level=9" \
+            ./result
+
+          tar --zstd -cf zen-browser-cache.tar.zst \
+            zen-cache result-path.txt
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: zen-browser-source-x86_64-linux
+          path: zen-browser-cache.tar.zst
+          compression-level: 0
+          retention-days: 3

--- a/default.nix
+++ b/default.nix
@@ -2,24 +2,44 @@
   pkgs ? import <nixpkgs> {},
   system ? pkgs.stdenv.hostPlatform.system,
 }: let
+  sources = builtins.fromJSON (builtins.readFile ./sources.json);
+
   mkZen = name: entry: let
-    variant = (builtins.fromJSON (builtins.readFile ./sources.json)).variants.${entry}.${system};
+    variant = sources.variants.${entry}.${system};
   in
     pkgs.callPackage ./package.nix {
       inherit name variant;
     };
-in rec {
-  beta-unwrapped = mkZen "beta" "beta";
-  twilight-unwrapped = mkZen "twilight" "twilight";
-  twilight-official-unwrapped = mkZen "twilight" "twilight-official";
 
-  beta = pkgs.wrapFirefox beta-unwrapped {
-    icon = "zen-browser";
-  };
-  twilight = pkgs.wrapFirefox twilight-unwrapped {};
-  twilight-official = pkgs.wrapFirefox twilight-official-unwrapped {
-    icon = "zen-twilight";
+  binaryPackages = rec {
+    beta-unwrapped = mkZen "beta" "beta";
+    twilight-unwrapped = mkZen "twilight" "twilight";
+    twilight-official-unwrapped = mkZen "twilight" "twilight-official";
+
+    beta = pkgs.wrapFirefox beta-unwrapped {
+      icon = "zen-browser";
+    };
+    twilight = pkgs.wrapFirefox twilight-unwrapped {};
+    twilight-official = pkgs.wrapFirefox twilight-official-unwrapped {
+      icon = "zen-twilight";
+    };
+
+    default = beta;
   };
 
-  default = beta;
-}
+  sourcePackages = pkgs.lib.optionalAttrs (system == "x86_64-linux") rec {
+    surfer = pkgs.callPackage ./surfer.nix {
+      source = sources.source.beta.surfer;
+    };
+
+    beta-source-unwrapped = pkgs.callPackage ./source-package.nix {
+      source = sources.source.beta;
+      inherit surfer;
+    };
+
+    beta-source = pkgs.wrapFirefox beta-source-unwrapped {
+      icon = "zen-browser";
+    };
+  };
+in
+  binaryPackages // sourcePackages

--- a/patches/surfer-disable-update-check.patch
+++ b/patches/surfer-disable-update-check.patch
@@ -1,0 +1,9 @@
+diff --git a/src/middleware/update-check.ts b/src/middleware/update-check.ts
+index 56952ee..3533d35 100644
+--- a/src/middleware/update-check.ts
++++ b/src/middleware/update-check.ts
+@@ -6,2 +6,4 @@
+ export const updateCheck = async (): Promise<void> => {
++  if (process.env.SURFER_DISABLE_UPDATE_CHECK === '1') return
++
+   const firefoxVersion = config.version.version

--- a/patches/surfer-static-changeset.patch
+++ b/patches/surfer-static-changeset.patch
@@ -1,0 +1,10 @@
+diff --git a/src/commands/build.ts b/src/commands/build.ts
+index 30e712a..1fa1b58 100644
+--- a/src/commands/build.ts
++++ b/src/commands/build.ts
+@@ -30 +30 @@ const applyConfig = async (os: string) => {
+-  let changeset
++  let changeset = process.env.SURFER_CHANGESET || ''
+@@ -32 +32 @@ const applyConfig = async (os: string) => {
+-  try {
++  if (!changeset) try {

--- a/source-package.nix
+++ b/source-package.nix
@@ -1,0 +1,120 @@
+{
+  source,
+  surfer,
+  lib,
+  stdenv,
+  buildMozillaMach,
+  fetchFromGitHub,
+  fetchurl,
+  git,
+  python3,
+  rustPlatform,
+}: let
+  inherit (source) version firefoxVersion;
+
+  desktop = fetchFromGitHub {
+    owner = "zen-browser";
+    repo = "desktop";
+    inherit (source) rev hash;
+  };
+
+  firefox = fetchurl {
+    url = "mirror://mozilla/firefox/releases/${firefoxVersion}/source/firefox-${firefoxVersion}.source.tar.xz";
+    hash = source.firefoxHash;
+  };
+
+  ffprefs = rustPlatform.buildRustPackage {
+    pname = "zen-ffprefs";
+    inherit version;
+    src = desktop;
+    sourceRoot = "source/tools/ffprefs";
+    cargoHash = source.cargoHash;
+  };
+
+  preparedSource = stdenv.mkDerivation {
+    pname = "zen-browser-prepared-source";
+    inherit version;
+    src = desktop;
+
+    nativeBuildInputs = [
+      ffprefs
+      git
+      python3
+      surfer
+    ];
+
+    dontConfigure = true;
+    dontFixup = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+      export SURFER_COMPAT=x86_64
+      export SURFER_CHANGESET=${source.rev}
+      export SURFER_DISABLE_UPDATE_CHECK=1
+      export SURFER_MOZCONFIG_ONLY=1
+      export ZEN_DOWNLOAD_DONT_INIT_GIT=1
+      export ZEN_RELEASE=1
+
+      surfer ci --brand release --display-version ${version}
+
+      mkdir -p .surfer/engine
+      install -Dm644 \
+        ${firefox} \
+        .surfer/engine/firefox-${firefoxVersion}.source.tar.xz
+
+      surfer download
+      ffprefs "$PWD"
+      python3 scripts/update_service_dumps.py
+      surfer import
+      surfer build --skip-patch-check
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out"
+      cp -aL engine/. "$out/"
+
+      runHook postInstall
+    '';
+  };
+in
+  ((buildMozillaMach {
+      pname = "zen-beta-source";
+      packageVersion = version;
+      version = firefoxVersion;
+      src = preparedSource;
+      applicationName = "Zen Browser (Beta)";
+      binaryName = "zen-beta";
+      branding = "browser/branding/release";
+      requireSigning = false;
+      allowAddonSideload = true;
+      extraPassthru = {
+        inherit preparedSource;
+      };
+
+      meta = {
+        description = "Zen Browser built from source";
+        homepage = "https://zen-browser.app";
+        changelog = "https://github.com/zen-browser/desktop/releases";
+        license = lib.licenses.mpl20;
+        mainProgram = "zen-beta";
+        platforms = ["x86_64-linux"];
+        sourceProvenance = with lib.sourceTypes; [fromSource];
+      };
+    }).override {
+      crashreporterSupport = false;
+      enableDebugSymbols = false;
+      enableOfficialBranding = false;
+      ltoSupport = false;
+      pgoSupport = false;
+    }).overrideAttrs (old: {
+    patches =
+      builtins.filter (
+        patch: !lib.hasInfix "link-freebl-explicitly-for-system-nss-builds" (toString patch)
+      )
+      old.patches;
+  })

--- a/sources.json
+++ b/sources.json
@@ -61,6 +61,22 @@
       }
     }
   },
+  "source": {
+    "beta": {
+      "version": "1.21.9b",
+      "rev": "fb2a85908268d25b2d62fd60c0c86891ef910a4b",
+      "hash": "sha256-Tfp+aAl9G53x6v82Bnts3mMafGDYCbLtlpFPV0Xb79Q=",
+      "firefoxVersion": "153.0",
+      "firefoxHash": "sha256-vFEPdMjExpLTHlWa61hQhJ0TvJghSsgeAE9m+BmlVSI=",
+      "cargoHash": "sha256-DZMwxeulQiIiSATU0MoyqiUMA0USZq6umhkr67hZH1Q=",
+      "surfer": {
+        "version": "1.14.6",
+        "rev": "39157caa384f9cc1e22e2aa1041ed374e2958781",
+        "hash": "sha256-V6PTy6gEqtA9nxzrj7nv5S9+UdZ4yTwmVhCkyZnBdd0=",
+        "npmDepsHash": "sha256-S7GjJLeHZjRpOD+99F7CCHFdqlNLrbS9g5KkhVxAbzI="
+      }
+    }
+  },
   "addons": {
     "sine": {
       "manager": {

--- a/surfer.nix
+++ b/surfer.nix
@@ -1,0 +1,39 @@
+{
+  source,
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  pkg-config,
+  vips,
+}:
+buildNpmPackage {
+  pname = "surfer";
+  inherit (source) version;
+
+  src = fetchFromGitHub {
+    owner = "zen-browser";
+    repo = "surfer";
+    inherit (source) rev hash;
+  };
+
+  patches = [
+    ./patches/surfer-disable-update-check.patch
+    ./patches/surfer-static-changeset.patch
+  ];
+
+  inherit (source) npmDepsHash;
+  npmFlags = ["--legacy-peer-deps"];
+  makeCacheWritable = true;
+  SHARP_IGNORE_GLOBAL_LIBVIPS = false;
+
+  nativeBuildInputs = [pkg-config];
+  buildInputs = [vips];
+
+  meta = {
+    description = "Build system for Firefox forks";
+    homepage = "https://github.com/zen-browser/surfer";
+    license = lib.licenses.mpl20;
+    mainProgram = "surfer";
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
Package Surfer 1.14.6 with pinned npm dependencies and libvips support. Patch its update middleware for offline builds and allow the desktop revision to be injected instead of requiring Git metadata.

Fetch the pinned Zen desktop revision and Firefox 153.0 source, build ffprefs, update service dumps, and apply the complete Surfer patch stack. Generate mozconfig without compiling inside Surfer and dereference overlay symlinks when exporting the prepared source tree.

Build the prepared tree through buildMozillaMach as zen-beta. Remove the redundant Firefox 153 system-NSS patch already present in Zen, disable PGO and LTO for bounded CI memory use, and expose surfer, beta-source-unwrapped, and beta-source on x86_64-linux.

Add a manual Blacksmith workflow that builds beta-source, reports closure size, exports the result closure as a portable zstd-compressed Nix file cache, and uploads it for three days.

Validated with nix flake check --no-build, source package evaluation, a patched Surfer build, prepared-source realization, workflow lint, and Mozilla compilation through generated bindings, DOM, media, WebRTC, graphics, and Skia (partially built).