### PR TITLE
fix(certificates): register p11-kit trust module as a security device

### DIFF
--- a/examples/03-policies-package-override.nix
+++ b/examples/03-policies-package-override.nix
@@ -5,6 +5,7 @@
 {
   inputs,
   system,
+  pkgs,
   ...
 }: {
   home.packages = [
@@ -13,6 +14,14 @@
         extraPolicies = {
           DisableAppUpdate = true;
           DisableTelemetry = true;
+
+          # The package already registers "System Trust" so `security.pki.*`
+          # reaches Zen. Merging is per top-level key, so redefining
+          # SecurityDevices drops it unless repeated here.
+          SecurityDevices = {
+            "System Trust" = "${pkgs.p11-kit}/lib/pkcs11/p11-kit-trust.so";
+            "OpenSC" = "${pkgs.opensc}/lib/opensc-pkcs11.so";
+          };
         };
       }
     )

--- a/package.nix
+++ b/package.nix
@@ -20,6 +20,7 @@
   libXtst,
   libva,
   libGL,
+  p11-kit,
   pciutils,
   pipewire,
   adwaita-icon-theme,
@@ -52,8 +53,18 @@
     aarch64-darwin = "darwin-aarch64";
   };
 
+  # Zen ships no libnssckbi.so, so NSS falls back to the roots compiled into
+  # libxul and never reads the system trust store. This module is additive:
+  # `security.pki.*` anchors become visible, built-in roots stay as fallback.
+  basePolicies = lib.optionalAttrs stdenv.hostPlatform.isLinux {
+    SecurityDevices = {
+      "System Trust" = "${p11-kit}/lib/pkcs11/p11-kit-trust.so";
+    };
+  };
+
   firefoxPolicies =
-    (config.firefox.policies or {})
+    basePolicies
+    // (config.firefox.policies or {})
     // policies
     // extraPolicies;
 

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -21,36 +21,38 @@
     pkgs.testers.nixosTest {
       inherit name;
       nodes.machine = {
-        imports = [
-          {
-            imports = [home-manager.nixosModules.home-manager];
+        imports =
+          [
+            {
+              imports = [home-manager.nixosModules.home-manager];
 
-            environment.systemPackages = with pkgs; [
-              jq
-              mozlz4a
-              xorg-server
-            ];
+              environment.systemPackages = with pkgs; [
+                jq
+                mozlz4a
+                xorg-server
+              ];
 
-            users.users.testuser = {
-              isNormalUser = true;
-              home = "/home/testuser";
-              createHome = true;
-              group = "users";
-              uid = 1000;
-            };
-
-            home-manager = {
-              useGlobalPkgs = true;
-              useUserPackages = true;
-
-              users.testuser = {
-                imports = [suite.homeModule];
-
-                home.stateVersion = "26.05";
+              users.users.testuser = {
+                isNormalUser = true;
+                home = "/home/testuser";
+                createHome = true;
+                group = "users";
+                uid = 1000;
               };
-            };
-          }
-        ];
+
+              home-manager = {
+                useGlobalPkgs = true;
+                useUserPackages = true;
+
+                users.testuser = {
+                  imports = [suite.homeModule];
+
+                  home.stateVersion = "26.05";
+                };
+              };
+            }
+          ]
+          ++ (suite.machineModules or []);
       };
 
       testScript = ''
@@ -77,6 +79,7 @@
     "env-vars" = ./env-vars.nix;
     "preset-cleanup" = ./preset-cleanup.nix;
     "extension-buttons" = ./extension-buttons.nix;
+    "system-certificates" = ./system-certificates.nix;
   };
 in
   pkgs.lib.mapAttrs (name: path: mkGenericTest name path) suites

--- a/tests/system-certificates.nix
+++ b/tests/system-certificates.nix
@@ -1,0 +1,143 @@
+{
+  pkgs,
+  zen-browser-flake,
+  ...
+}: let
+  trustedHost = "zen-flake-trusted.local";
+  untrustedHost = "zen-flake-untrusted.local";
+
+  trustedCaName = "Zen Flake Trusted CA";
+
+  certs = pkgs.runCommand "zen-test-certs" {nativeBuildInputs = [pkgs.openssl];} ''
+    mkdir -p $out
+
+    mkCa() {
+      openssl req -x509 -newkey rsa:2048 -nodes -sha256 -days 3650 \
+        -keyout "$out/$1.ca.key" -out "$out/$1.ca.crt" \
+        -subj "/CN=$2" \
+        -addext "basicConstraints=critical,CA:TRUE" \
+        -addext "keyUsage=critical,keyCertSign,cRLSign"
+    }
+
+    mkCert() {
+      openssl req -newkey rsa:2048 -nodes -sha256 \
+        -keyout "$out/$1.key" -out "$out/$1.csr" -subj "/CN=$2"
+
+      openssl x509 -req -in "$out/$1.csr" -days 3650 -sha256 \
+        -CA "$out/$1.ca.crt" -CAkey "$out/$1.ca.key" -CAcreateserial \
+        -out "$out/$1.crt" \
+        -extfile <(printf "subjectAltName=DNS:%s\nbasicConstraints=critical,CA:FALSE\nextendedKeyUsage=serverAuth\n" "$2")
+    }
+
+    mkCa trusted "${trustedCaName}"
+    mkCa untrusted "Zen Flake Untrusted CA"
+
+    mkCert trusted "${trustedHost}"
+    mkCert untrusted "${untrustedHost}"
+  '';
+
+  # Onboarding and the default-browser prompt cover the page in the screenshot.
+  probePrefs = pkgs.writeText "user.js" ''
+    user_pref("zen.welcome-screen.seen", true);
+    user_pref("browser.aboutwelcome.enabled", false);
+    user_pref("browser.startup.homepage_override.mstone", "ignore");
+    user_pref("browser.shell.checkDefaultBrowser", false);
+  '';
+
+  webroot = pkgs.runCommand "zen-test-webroot" {} ''
+    mkdir -p $out
+    echo "<!doctype html><title>zen tls probe</title><body>ok</body>" > $out/index.html
+  '';
+
+  mkVhost = tag: {
+    addSSL = true;
+    sslCertificate = "${certs}/${tag}.crt";
+    sslCertificateKey = "${certs}/${tag}.key";
+    root = webroot;
+    extraConfig = "access_log /var/log/nginx/${tag}.log;";
+  };
+in {
+  machineModules = [
+    {
+      virtualisation.memorySize = 4096;
+
+      environment.systemPackages = [pkgs.nss.tools pkgs.imagemagick pkgs.xwd];
+
+      security.pki.certificateFiles = ["${certs}/trusted.ca.crt"];
+
+      networking.hosts."127.0.0.1" = [trustedHost untrustedHost];
+
+      services.nginx = {
+        enable = true;
+        virtualHosts = {
+          ${trustedHost} = mkVhost "trusted";
+          ${untrustedHost} = mkVhost "untrusted";
+        };
+      };
+    }
+  ];
+
+  homeModule = {
+    imports = [zen-browser-flake.homeModules.beta];
+
+    programs.zen-browser.enable = true;
+  };
+
+  testScript = ''
+    machine.wait_for_unit("nginx.service")
+    machine.wait_for_open_port(443)
+
+    machine.succeed(
+        "grep -q '${trustedCaName}' /etc/ssl/trust-source/ca-bundle.trust.p11-kit"
+    )
+
+    # Firefox refuses to create a missing --profile directory.
+    machine.succeed("install -d -o testuser -g users /home/testuser/probe")
+    machine.succeed(
+        "install -o testuser -g users -m 644 ${probePrefs} /home/testuser/probe/user.js"
+    )
+
+    machine.succeed("( nohup Xvfb :99 -screen 0 1024x768x24 </dev/null >>/tmp/xvfb.log 2>&1 & )")
+    machine.sleep(2)
+
+
+    def launch(urls, shot, settle=60):
+        machine.succeed(
+            "su - testuser -c '"
+            f"DISPLAY=:99 nohup zen-beta --profile /home/testuser/probe {urls}"
+            " >>/tmp/zen.log 2>&1 &'"
+        )
+        machine.sleep(settle)
+        # Xvfb is not the QEMU console, so machine.screenshot() would miss it.
+        machine.succeed(f"xwd -root -display :99 -silent | convert xwd:- png:/tmp/{shot}")
+        machine.copy_from_machine(f"/tmp/{shot}", "")
+        machine.succeed("pkill -u testuser -f zen || true")
+        machine.sleep(3)
+
+
+    launch("https://${trustedHost}/", "zen-trusted.png")
+
+    machine.succeed("grep -q 'System Trust' /home/testuser/probe/pkcs11.txt")
+
+    anchors = machine.succeed("certutil -L -d sql:/home/testuser/probe -h 'System Trust'")
+    ca = [line for line in anchors.splitlines() if "${trustedCaName}" in line]
+    assert ca, anchors
+    # Trailing trust triple; "CT" means trusted CA for TLS server auth.
+    assert ca[0].split()[-1].startswith("CT"), ca[0]
+
+    # A rejected chain aborts the handshake, so nginx would log nothing.
+    machine.succeed("grep -q 'GET / ' /var/log/nginx/trusted.log")
+
+    # The trusted host is repeated as a positive control: without it a broken
+    # launch would satisfy the negative assertions for the wrong reason.
+    launch(
+        "https://${untrustedHost}/ https://${trustedHost}/",
+        "zen-untrusted.png",
+    )
+
+    served = int(machine.succeed("grep -c 'GET / ' /var/log/nginx/trusted.log"))
+    assert served >= 2, f"second launch never reached the trusted host ({served} requests)"
+
+    machine.fail("grep -q 'GET / ' /var/log/nginx/untrusted.log")
+  '';
+}


### PR DESCRIPTION
package.nix: add a `SecurityDevices` entry to a new `basePolicies` attrset on
linux, pointing at `p11-kit-trust.so`, merged as the base layer under
`config.firefox.policies`, `policies` and `extraPolicies`. Zen ships no
`libnssckbi.so`, so NSS falls back to the roots compiled into libxul and never
reads `/etc/ssl/trust-source`, which is why `security.pki.certificates` and
`security.pki.certificateFiles` have no effect today. Loading the module is
additive (`trustOrder` 100 against the internal module's 75), so the built-in
roots stay as the fallback and the module can only add trust, never remove it.
Darwin is excluded, so the assertion forbidding policy overrides on the signed
`.app` still holds.

This has to live in the package rather than the Home Manager module because
`wrapFirefox` only copies files named after `binaryName`; Zen's in-libDir
executable is `zen` while `binaryName` is `zen-beta`, so the wrapper's
`distribution/policies.json` is not the one Firefox resolves at runtime.

tests/system-certificates.nix: new VM test serving two TLS vhosts, one signed by
a CA installed through `security.pki.certificateFiles` and one by a CA that is
deliberately not installed. It asserts the anchor lands in `/etc/ssl/trust-source`,
that the profile's `pkcs11.txt` registers `System Trust`, that `certutil` lists
the CA with `CT` trust, and that nginx logs the request for the trusted host. The
untrusted host is then loaded alongside the trusted one and asserted absent from
its access log, with the repeated trusted request as a liveness control so a
crashed launch cannot satisfy the negative assertion vacuously. Both launches
capture the Xvfb root window to `$out/zen-trusted.png` and `$out/zen-untrusted.png`.

tests/default.nix: extend `mkGenericTest` with an optional `machineModules` for
NixOS-level configuration, and register the suite.

examples/03-policies-package-override.nix: repeat the `System Trust` entry, since
policies merge per top-level key and redefining `SecurityDevices` would otherwise
drop it.

Fixes https://github.com/0xc000022070/zen-browser-flake/issues/225.
