### PR TITLE
docs(examples): nest a folder inside the toolbar directory in 07-bookmarks

### DIFF
--- a/examples/07-bookmarks.nix
+++ b/examples/07-bookmarks.nix
@@ -1,24 +1,34 @@
 # Bookmark organization with toolbar bookmarks
+#
+# `toolbar = true` marks a directory AS the bookmarks toolbar (its name is
+# discarded), it does not put that directory inside the toolbar. To get a
+# folder on the toolbar, nest it inside the toolbar directory.
+# Directories without `toolbar` land in the bookmarks menu.
 {
   programs.zen-browser.profiles.default.bookmarks = {
     force = true; # Rewrite bookmarks on each rebuild (overwrite browser changes)
     settings = [
       {
-        name = "Nix Sites";
+        name = "Bookmarks Toolbar";
         toolbar = true;
         bookmarks = [
           {
-            name = "homepage";
-            url = "https://nixos.org/";
-          }
-          {
-            name = "wiki";
-            tags = ["wiki" "nix"];
-            url = "https://wiki.nixos.org/";
-          }
-          {
-            name = "packages";
-            url = "https://search.nixos.org/packages";
+            name = "Nix Sites";
+            bookmarks = [
+              {
+                name = "homepage";
+                url = "https://nixos.org/";
+              }
+              {
+                name = "wiki";
+                tags = ["wiki" "nix"];
+                url = "https://wiki.nixos.org/";
+              }
+              {
+                name = "packages";
+                url = "https://search.nixos.org/packages";
+              }
+            ];
           }
         ];
       }


### PR DESCRIPTION
Wrap the `toolbar = true` directory around a "Nix Sites" child directory instead of listing the bookmarks directly under it, and add a header comment stating that `toolbar = true` marks a directory AS the bookmarks toolbar rather than placing it inside the toolbar; home-manager discards the directory name and emits PERSONAL_TOOLBAR_FOLDER="true", so the previous shape rendered three loose bookmarks on the toolbar with no visible folder.

Ref: https://github.com/nix-community/home-manager/blob/a45a7c451455a51ae740ec3bce4024b312809c29/modules/programs/firefox/profiles/bookmarks.nix#L37-L46