### PR TITLE
fix(hm): restore policies on the linux unwrapped override

### DIFF
--- a/hm-module/package.nix
+++ b/hm-module/package.nix
@@ -133,10 +133,14 @@ in {
         basePackage = applyEnv (
           if cfg.unwrappedPackage != null
           then cfg.unwrappedPackage
+          # Policies belong to the unwrapped derivation: wrapFirefox writes its
+          # own distribution/policies.json, but the launcher execs through to
+          # the unwrapped binary and Gecko reads the file next to
+          # /proc/self/exe, so the wrapper's copy is never loaded.
           else if isLinux
           then
             self.packages.${pkgs.stdenv.hostPlatform.system}."${name}-unwrapped".override {
-              inherit (cfg) enablePrivateDesktopEntry;
+              inherit (cfg) policies enablePrivateDesktopEntry;
             }
           else self.packages.${pkgs.stdenv.hostPlatform.system}."${name}-unwrapped"
         );

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -73,6 +73,7 @@
     "space-routing" = ./space-routing.nix;
     "default-browser" = ./default-browser.nix;
     "private-desktop-entry" = ./private-desktop-entry.nix;
+    "policies" = ./policies.nix;
     "env-vars" = ./env-vars.nix;
     "preset-cleanup" = ./preset-cleanup.nix;
   };

--- a/tests/policies.nix
+++ b/tests/policies.nix
@@ -1,0 +1,45 @@
+{zen-browser-flake, ...}: {
+  homeModule = {
+    imports = [zen-browser-flake.homeModules.beta];
+
+    programs.zen-browser = {
+      enable = true;
+
+      policies = {
+        AutofillCreditCardEnabled = false;
+        BlockAboutConfig = true;
+      };
+    };
+  };
+
+  # Gecko resolves its application directory from /proc/self/exe, so the only
+  # policies.json it reads is the one next to the fully dereferenced binary.
+  # wrapFirefox writes its own copy into the wrapper's lib dir, which the
+  # launcher never reaches: it execs straight through to the unwrapped store
+  # path.
+  testScript = ''
+    import json
+
+    pkg_path = machine.succeed(
+      "su - testuser -c 'readlink -f $(which zen-beta)' | sed \"s|/bin/zen-beta$||\""
+    ).strip()
+
+    app_dir = machine.succeed(
+      f"dirname $(readlink -f {pkg_path}/lib/zen-bin-*/zen)"
+    ).strip()
+
+    policies = json.loads(
+      machine.succeed(f"cat {app_dir}/distribution/policies.json")
+    )["policies"]
+
+    assert policies.get("AutofillCreditCardEnabled") is False, \
+      f"declared policy missing from {app_dir}/distribution/policies.json: {policies}"
+    assert policies.get("BlockAboutConfig") is True, \
+      f"declared policy missing from {app_dir}/distribution/policies.json: {policies}"
+
+    assert policies.get("DisableAppUpdate") is True, \
+      f"module default policy missing: {policies}"
+    assert policies.get("DisableTelemetry") is True, \
+      f"module default policy missing: {policies}"
+  '';
+}


### PR DESCRIPTION
hm-module/package.nix: re-add `policies` to the `*-unwrapped` override dropped in 17a400c, so distribution/policies.json is written into the derivation the launcher dereferences to.

tests/policies.nix: nixos test declaring two policies, resolving the app dir through `readlink -f $pkg/lib/zen-bin-*/zen` and asserting the declared keys plus the module defaults land in that policies.json. Checking the wrapper's own lib dir would pass either way, since mkFirefoxModule feeds cfg.policies to wrapFirefox as extraPolicies.

tests/default.nix: register the suite as "policies".