### PR TITLE
feat(hm): assert sine.enable against extraPrefs and extraPrefsFilesBoth

### DIFF
--- a/hm-module/default.nix
+++ b/hm-module/default.nix
@@ -209,6 +209,11 @@ in {
           message = "Profile '${profileName}': sine.mods requires sine.enable to be true.";
         })
         cfg.profiles)
+      ++ (lib.mapAttrsToList (profileName: profile: {
+          assertion = !(profile.sine.enable && (cfg.extraPrefs != "" || cfg.extraPrefsFiles != []));
+          message = "Profile '${profileName}': sine.enable is mutually exclusive with extraPrefs and extraPrefsFiles. Both claim general.config.filename in the application directory and sine's bootloader wins, so the extra prefs would be dropped without notice. Put them in profiles.${profileName}.settings instead.";
+        })
+        cfg.profiles)
       ++ (lib.flatten (lib.mapAttrsToList (
           profileName: profile:
             lib.mapAttrsToList (groupName: group: [


### PR DESCRIPTION
register their file through the application directory's autoconfigslot: sine writes defaults/pref/config-pref.js pointing at config.js,wrapFirefox writes defaults/pref/autoconfig.js pointing at mozilla.cfg.Only one general.config.filename survives and config-pref.js sorts last,so the extra prefs go missing with no diagnostic.