### PR TITLE
hm-module: suppress pinned tab window sync warning appropriately

### DIFF
--- a/hm-module/default.nix
+++ b/hm-module/default.nix
@@ -78,8 +78,8 @@ in {
       essentialPinsWarning = let
         hasIssue = lib.any (
           profile:
-            ((profile.settings or {})."zen.window-sync.enabled" or true)
-            == false
+            (((profile.settings or {})."zen.window-sync.enabled" or true) == false
+            && ((profile.settings or {})."zen.window-sync.sync-only-pinned-tabs" or true) == false)
             && lib.any (p: p.isEssential or false) (lib.attrValues (profile.pinsResolved or {}))
         ) (lib.attrValues cfg.profiles);
       in


### PR DESCRIPTION
When `profiles.*.settings.zen.window-sync.sync-only-pinned-tabs` is `true`, the warning about pinned tabs not syncing across windows isn't suppressed, despite the warning message.