### PR TITLE
Revert "chore(update): ffmpeg_8 -> ffmpeg_9 (#381)"

### DIFF
--- a/hm-module/package.nix
+++ b/hm-module/package.nix
@@ -165,13 +165,7 @@ in {
           else basePackage;
 
         wrappedPackage =
-          # wrapFirefox's function signature (see wrapper.nix) declares
-          # `ffmpeg_8` as a formal parameter — there is no `ffmpeg_9`
-          # parameter to override. The `.override` mechanism works on
-          # parameter names, so we must override `ffmpeg_8` (the name
-          # wrapFirefox accepts) and set its value to `pkgs.ffmpeg_9`
-          # (the actual package we want)
-          ((pkgs.wrapFirefox.override {ffmpeg_8 = pkgs.ffmpeg_9;}) (prepareDarwinWrapper (getPackage isSineEnabled)) {
+          ((pkgs.wrapFirefox.override {ffmpeg_7 = pkgs.ffmpeg_8;}) (prepareDarwinWrapper (getPackage isSineEnabled)) {
             icon =
               if cfg.icon != null
               then cfg.icon

--- a/package.nix
+++ b/package.nix
@@ -10,7 +10,7 @@
   config,
   wrapGAppsHook3,
   autoPatchelfHook,
-  ffmpeg_9,
+  ffmpeg_8,
   alsa-lib,
   curl,
   dbus-glib,
@@ -210,7 +210,7 @@ in
       alsa-lib
       dbus-glib
       libXtst
-      ffmpeg_9
+      ffmpeg_8
     ];
 
     runtimeDependencies = lib.optionals stdenv.hostPlatform.isLinux [
@@ -230,7 +230,7 @@ in
 
     preFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
       gappsWrapperArgs+=(
-        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ffmpeg_9]}"
+        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ffmpeg_8]}"
         --add-flags "--name=''${MOZ_APP_LAUNCHER:-${binaryName}}"
         --add-flags "--class=''${MOZ_APP_LAUNCHER:-${binaryName}}"
       )


### PR DESCRIPTION
Reverts 0xc000022070/zen-browser-flake#381

`ffmpeg_9` isn't available on the 26.05 channel yet (only `ffmpeg_4`/`6`/`7`/`8` are packaged there). 

Closes #382 

cc @luisnquin 