### PR TITLE
fix(ffmpeg): pin both wrapFirefox ffmpeg slots, fall back to ffmpeg_8

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,6 +4,18 @@
 }: let
   isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
 
+  # wrapper.nix picks between its `ffmpeg_7` and `ffmpeg_8` formals with
+  # `versionAtLeast browser.version "146"`, which reads Zen's "1.21.15b" rather
+  # than a Gecko number and so always resolves to `ffmpeg_7`. Override both
+  # slots so the branch it takes stops mattering. Both formals exist since
+  # 26.05; 25.11 and older declare only `ffmpeg_7` and throw here.
+  zenFfmpeg = pkgs.ffmpeg_9 or pkgs.ffmpeg_8;
+
+  wrapZen = pkgs.wrapFirefox.override {
+    ffmpeg_7 = zenFfmpeg;
+    ffmpeg_8 = zenFfmpeg;
+  };
+
   mkZen = name: entry: let
     variant = (builtins.fromJSON (builtins.readFile ./sources.json)).variants.${entry}.${system};
   in
@@ -19,18 +31,18 @@ in rec {
     if isDarwin
     then beta-unwrapped
     else
-      pkgs.wrapFirefox beta-unwrapped {
+      wrapZen beta-unwrapped {
         icon = "zen-browser";
       };
   twilight =
     if isDarwin
     then twilight-unwrapped
-    else pkgs.wrapFirefox twilight-unwrapped {};
+    else wrapZen twilight-unwrapped {};
   twilight-official =
     if isDarwin
     then twilight-official-unwrapped
     else
-      pkgs.wrapFirefox twilight-official-unwrapped {
+      wrapZen twilight-official-unwrapped {
         icon = "zen-twilight";
       };
 

--- a/hm-module/package.nix
+++ b/hm-module/package.nix
@@ -164,14 +164,14 @@ in {
             })
           else basePackage;
 
-        wrappedPackage =
-          # wrapFirefox's function signature (see wrapper.nix) declares
-          # `ffmpeg_8` as a formal parameter — there is no `ffmpeg_9`
-          # parameter to override. The `.override` mechanism works on
-          # parameter names, so we must override `ffmpeg_8` (the name
-          # wrapFirefox accepts) and set its value to `pkgs.ffmpeg_9`
-          # (the actual package we want)
-          ((pkgs.wrapFirefox.override {ffmpeg_8 = pkgs.ffmpeg_9;}) (prepareDarwinWrapper (getPackage isSineEnabled)) {
+        # Same wrapper slot pinning as default.nix, against the user's pkgs.
+        zenFfmpeg = pkgs.ffmpeg_9 or pkgs.ffmpeg_8;
+
+        wrappedPackage = ((pkgs.wrapFirefox.override {
+            ffmpeg_7 = zenFfmpeg;
+            ffmpeg_8 = zenFfmpeg;
+          })
+          (prepareDarwinWrapper (getPackage isSineEnabled)) {
             icon =
               if cfg.icon != null
               then cfg.icon
@@ -179,9 +179,9 @@ in {
               then "zen-browser"
               else "zen-${name}";
           }).override {
-            inherit (cfg) extraPrefs extraPrefsFiles;
-            nativeMessagingHosts = lib.optionals isLinux cfg.nativeMessagingHosts;
-          };
+          inherit (cfg) extraPrefs extraPrefsFiles;
+          nativeMessagingHosts = lib.optionals isLinux cfg.nativeMessagingHosts;
+        };
 
         selectedPackage =
           if isSignedDarwin

--- a/package.nix
+++ b/package.nix
@@ -10,7 +10,9 @@
   config,
   wrapGAppsHook3,
   autoPatchelfHook,
-  ffmpeg_9,
+  ffmpeg_8,
+  # ffmpeg_9 is absent on nixpkgs 26.05; Zen dlopens libavcodec 62 and 63
+  ffmpeg_9 ? ffmpeg_8,
   alsa-lib,
   curl,
   dbus-glib,


### PR DESCRIPTION
wrapper.nix resolves ffmpegPackage with `versionAtLeast browser.version "146"`, which reads Zen's "1.21.15b" rather than a Gecko version and so always lands on the ffmpeg_7 formal. Overriding ffmpeg_8 alone was never forced, and default.nix passed no override at all. Set both formals in default.nix and hm-module/package.nix.

package.nix now takes ffmpeg_9 with an ffmpeg_8 default so callPackage resolves on nixpkgs releases that predate ffmpeg_9.