### PR TITLE
fix(ffmpeg): fix eval on latest nixpkgs via browser.version fake

### DIFF
--- a/.github/update.sh
+++ b/.github/update.sh
@@ -198,6 +198,20 @@ update_version() {
     fi
     sha256=$(echo "$prefetch_output" | jq -r '.hash')
 
+    # Gecko milestone of the artifact, consumed by wrap-zen.nix. Missing
+    # milestone is not fatal: the wrapper falls back to its newest ffmpeg.
+    firefox_version_field=""
+    if [ "$os" != "darwin" ]; then
+        store_path=$(echo "$prefetch_output" | jq -r '.storePath')
+        firefox_version=$(sed -n 's/^Milestone=//p' "$store_path/platform.ini" | tr -d '[:space:]')
+
+        if [ "$firefox_version" = "" ]; then
+            echo "warning: no Gecko milestone found in $store_path/platform.ini" 1>&2
+        else
+            firefox_version_field=",\"firefoxVersion\":\"$firefox_version\""
+        fi
+    fi
+
     entry_name="$version_name"
 
     if [ "$version_name" = "twilight" ]; then
@@ -246,12 +260,12 @@ update_version() {
                     echo "[skipping] An artifact $artifact_name already exists in $release_name @ following link: $self_download_url"
                 fi
 
-                jq ".variants[\"twilight\"][\"$arch-$os\"] = {\"version\":\"$semver\",\"sha1\":\"$remote_sha1\",\"url\":\"$self_download_url\",\"sha256\":\"$sha256\"}" <sources.json >sources.json.tmp
+                jq ".variants[\"twilight\"][\"$arch-$os\"] = {\"version\":\"$semver\",\"sha1\":\"$remote_sha1\",\"url\":\"$self_download_url\",\"sha256\":\"$sha256\"$firefox_version_field}" <sources.json >sources.json.tmp
                 mv sources.json.tmp sources.json
             done
     fi
 
-    jq ".variants[\"$entry_name\"][\"$arch-$os\"] = {\"version\":\"$semver\",\"sha1\":\"$remote_sha1\",\"url\":\"$download_url\",\"sha256\":\"$sha256\"}" <sources.json >sources.json.tmp
+    jq ".variants[\"$entry_name\"][\"$arch-$os\"] = {\"version\":\"$semver\",\"sha1\":\"$remote_sha1\",\"url\":\"$download_url\",\"sha256\":\"$sha256\"$firefox_version_field}" <sources.json >sources.json.tmp
     mv sources.json.tmp sources.json
 
     echo "$version_name was updated to $semver"

--- a/default.nix
+++ b/default.nix
@@ -4,17 +4,7 @@
 }: let
   isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
 
-  # wrapper.nix picks between its `ffmpeg_7` and `ffmpeg_8` formals with
-  # `versionAtLeast browser.version "146"`, which reads Zen's "1.21.15b" rather
-  # than a Gecko number and so always resolves to `ffmpeg_7`. Override both
-  # slots so the branch it takes stops mattering. Both formals exist since
-  # 26.05; 25.11 and older declare only `ffmpeg_7` and throw here.
-  zenFfmpeg = pkgs.ffmpeg_9 or pkgs.ffmpeg_8;
-
-  wrapZen = pkgs.wrapFirefox.override {
-    ffmpeg_7 = zenFfmpeg;
-    ffmpeg_8 = zenFfmpeg;
-  };
+  wrapZen = import ./wrap-zen.nix pkgs.wrapFirefox;
 
   mkZen = name: entry: let
     variant = (builtins.fromJSON (builtins.readFile ./sources.json)).variants.${entry}.${system};

--- a/hm-module/package.nix
+++ b/hm-module/package.nix
@@ -164,14 +164,10 @@ in {
             })
           else basePackage;
 
-        # Same wrapper slot pinning as default.nix, against the user's pkgs.
-        zenFfmpeg = pkgs.ffmpeg_9 or pkgs.ffmpeg_8;
+        wrapZen = import ../wrap-zen.nix pkgs.wrapFirefox;
 
-        wrappedPackage = ((pkgs.wrapFirefox.override {
-            ffmpeg_7 = zenFfmpeg;
-            ffmpeg_8 = zenFfmpeg;
-          })
-          (prepareDarwinWrapper (getPackage isSineEnabled)) {
+        wrappedPackage =
+          (wrapZen (prepareDarwinWrapper (getPackage isSineEnabled)) {
             icon =
               if cfg.icon != null
               then cfg.icon
@@ -179,9 +175,9 @@ in {
               then "zen-browser"
               else "zen-${name}";
           }).override {
-          inherit (cfg) extraPrefs extraPrefsFiles;
-          nativeMessagingHosts = lib.optionals isLinux cfg.nativeMessagingHosts;
-        };
+            inherit (cfg) extraPrefs extraPrefsFiles;
+            nativeMessagingHosts = lib.optionals isLinux cfg.nativeMessagingHosts;
+          };
 
         selectedPackage =
           if isSignedDarwin

--- a/package.nix
+++ b/package.nix
@@ -245,12 +245,18 @@ in
       then installDarwin
       else installLinux;
 
-    passthru = {
-      inherit applicationName binaryName libName;
-      ffmpegSupport = true;
-      gssSupport = true;
-      gtk3 = gtk3;
-    };
+    passthru =
+      {
+        inherit applicationName binaryName libName;
+        ffmpegSupport = true;
+        gssSupport = true;
+        gtk3 = gtk3;
+      }
+      # Gecko milestone backing this Zen release; wrap-zen.nix feeds it to
+      # wrapFirefox's version checks in place of Zen's own version.
+      // lib.optionalAttrs (variant ? firefoxVersion) {
+        inherit (variant) firefoxVersion;
+      };
 
     meta = {
       description = "Experience tranquillity while browsing the web without people tracking you!";

--- a/sources.json
+++ b/sources.json
@@ -5,13 +5,15 @@
         "version": "1.21.15b",
         "sha1": "28167f86c52cd7ef12243a824d4f58144d15daa4",
         "url": "https://github.com/zen-browser/desktop/releases/download/1.21.15b/zen.linux-x86_64.tar.xz",
-        "sha256": "sha256-XzsrEmK5LXdMDOGuRRiA/bOIqa8TUGUZc+s2hWQzafw="
+        "sha256": "sha256-XzsrEmK5LXdMDOGuRRiA/bOIqa8TUGUZc+s2hWQzafw=",
+        "firefoxVersion": "154.0"
       },
       "aarch64-linux": {
         "version": "1.21.15b",
         "sha1": "28167f86c52cd7ef12243a824d4f58144d15daa4",
         "url": "https://github.com/zen-browser/desktop/releases/download/1.21.15b/zen.linux-aarch64.tar.xz",
-        "sha256": "sha256-h3MHg3UMqpdEvr6HifomMXTo5eihTrrDIkZzadR8A+s="
+        "sha256": "sha256-h3MHg3UMqpdEvr6HifomMXTo5eihTrrDIkZzadR8A+s=",
+        "firefoxVersion": "154.0"
       },
       "aarch64-darwin": {
         "version": "1.21.15b",
@@ -25,13 +27,15 @@
         "version": "1.22t",
         "sha1": "null",
         "url": "https://github.com/0xc000022070/zen-browser-flake/releases/download/1.22t-1787753211/zen.linux-x86_64.tar.xz",
-        "sha256": "sha256-n6ia+9ZBD/hv7althKdOyW0jPxZ/mxYrluefXgIKLiM="
+        "sha256": "sha256-n6ia+9ZBD/hv7althKdOyW0jPxZ/mxYrluefXgIKLiM=",
+        "firefoxVersion": "154.0.1"
       },
       "aarch64-linux": {
         "version": "1.22t",
         "sha1": "null",
         "url": "https://github.com/0xc000022070/zen-browser-flake/releases/download/1.22t-1787753211/zen.linux-aarch64.tar.xz",
-        "sha256": "sha256-ynejMlazZZ0e7DA6Ej/XhoTcQIn3Lq4xfEj48kHItEk="
+        "sha256": "sha256-ynejMlazZZ0e7DA6Ej/XhoTcQIn3Lq4xfEj48kHItEk=",
+        "firefoxVersion": "154.0.1"
       },
       "aarch64-darwin": {
         "version": "1.22t",
@@ -45,13 +49,15 @@
         "version": "1.22t",
         "sha1": "null",
         "url": "https://github.com/zen-browser/desktop/releases/download/twilight-1/zen.linux-x86_64.tar.xz",
-        "sha256": "sha256-n6ia+9ZBD/hv7althKdOyW0jPxZ/mxYrluefXgIKLiM="
+        "sha256": "sha256-n6ia+9ZBD/hv7althKdOyW0jPxZ/mxYrluefXgIKLiM=",
+        "firefoxVersion": "154.0.1"
       },
       "aarch64-linux": {
         "version": "1.22t",
         "sha1": "null",
         "url": "https://github.com/zen-browser/desktop/releases/download/twilight-1/zen.linux-aarch64.tar.xz",
-        "sha256": "sha256-ynejMlazZZ0e7DA6Ej/XhoTcQIn3Lq4xfEj48kHItEk="
+        "sha256": "sha256-ynejMlazZZ0e7DA6Ej/XhoTcQIn3Lq4xfEj48kHItEk=",
+        "firefoxVersion": "154.0.1"
       },
       "aarch64-darwin": {
         "version": "1.22t",

--- a/wrap-zen.nix
+++ b/wrap-zen.nix
@@ -1,0 +1,10 @@
+# wrapFirefox picks its ffmpeg by `versionAtLeast browser.version <N>`; Zen's
+# "1.21.15b" never clears that, so it's stuck on the oldest ffmpeg. Fake the
+# version for that check only, restore the real one everywhere else (#386).
+# `firefoxVersion` (the Gecko milestone recorded in sources.json) makes the
+# wrapper take exactly the branch it takes for the equivalent Firefox; packages
+# without it fall back to "always newest".
+wrapFirefox: unwrapped: config:
+wrapFirefox (unwrapped // {version = unwrapped.firefoxVersion or "9999";})
+({version = unwrapped.version;} // config)
+// {inherit unwrapped;}


### PR DESCRIPTION
wrapper.nix renamed its ffmpeg_7/ffmpeg_8 formals to ffmpeg_8/ffmpeg_9 on
nixos-unstable, so the .override from #384 fails eval with an unexpected
argument. wrap-zen.nix instead feeds a fake version into the wrapper's own
versionAtLeast check (falling back to "always newest"), passes the real
version for the output name, and restores the real unwrapped passthru.
Survives slot renames and threshold bumps; both call sites share it.

Fixes https://github.com/0xc000022070/zen-browser-flake/issues/386.