### PR TITLE
feat(live-folders): support nesting live folders under folders

### DIFF
--- a/examples/17-live-folders.nix
+++ b/examples/17-live-folders.nix
@@ -12,10 +12,22 @@
 # GitHub kinds reuse the browser's logged-in github.com session — no token.
 # Keep "zen.window-sync.enabled" = true (the default) or Zen may drop the
 # entries on restore.
+#
+# A live folder can be nested inside a regular folder pin via `folderParentId`
+# (Zen can't nest a live folder under another live folder, so the parent must
+# be a declared `isGroup = true` pin).
 {
   programs.zen-browser.profiles.default = let
     workSpaceId = "8a2c47f0-1d9e-4b36-a5c8-f70e92b4d615";
+    blogFolderId = "1f3d9b0c-4e7a-4a10-9b3d-2c8e6f1a0b5d";
   in {
+    pins."Blogs" = {
+      id = blogFolderId;
+      isGroup = true;
+      workspace = workSpaceId;
+      position = 399;
+    };
+
     liveFolders = {
       "Prisma blog" = {
         id = "0f3f2f66-64bc-4a43-8f86-01c2a134c4f4";
@@ -25,6 +37,8 @@
         workspace = workSpaceId;
         position = 400;
         maxItems = 5;
+        # Nest this live folder inside the "Blogs" folder pin above.
+        folderParentId = blogFolderId;
         # timeRange = 86400000;   # only items from the last 24 h; 0 (default) keeps all
         # fetchInterval = 900000; # 15 min; omit to let the browser manage it
       };

--- a/hm-module/default.nix
+++ b/hm-module/default.nix
@@ -278,6 +278,13 @@ in {
                 assertion = lf.workspace or null != null;
                 message = "Profile '${profileName}' liveFolders '${lfName}': workspace is required — Zen folders belong to exactly one space. Use spaces.<name>.liveFolders, or set workspace to a space id (without declared spaces: copy the zen.workspaces.active pref from about:config, minus the braces).";
               }
+              {
+                assertion =
+                  lf.folderParentId
+                  == null
+                  || lib.any (p: p.isGroup && p.id == lf.folderParentId) (lib.attrValues (profile.pinsResolved or {}));
+                message = "Profile '${profileName}' liveFolders '${lfName}': folderParentId must match the id of a pin with isGroup = true.";
+              }
             ])
             (profile.liveFolders or {})
         )

--- a/hm-module/lib/live-folder-options.nix
+++ b/hm-module/lib/live-folder-options.nix
@@ -1,6 +1,8 @@
 # Live-folder submodule shared by `liveFolders` and the space-scoped
 # `spaces.*.liveFolders`. Space-scoped folders exclude `workspace`: it is
 # derived from the owning space during desugaring (session/spaces.nix).
+# `folderParentId` stays in both forms; the parent is always a regular
+# folder pin, since Zen cannot nest a live folder under another live folder.
 {
   lib,
   includeWorkspace ? true,
@@ -41,6 +43,15 @@ in
           type = bool;
           default = true;
           description = "Whether the folder starts collapsed.";
+        };
+        folderParentId = mkOption {
+          type = nullOr str;
+          default = null;
+          description = ''
+            Pin UUID of a declared folder pin (`isGroup = true`) that contains
+            this live folder. Live folders cannot nest inside other live
+            folders in Zen, so the parent must be a regular folder pin.
+          '';
         };
         folderIcon = mkOption {
           type = nullOr (either str path);

--- a/hm-module/session/live-folders.nix
+++ b/hm-module/session/live-folders.nix
@@ -61,7 +61,10 @@ in {
                     name = lf.title;
                     collapsed = lf.collapsed;
                     saveOnWindowClose = true;
-                    parentId = null;
+                    parentId =
+                      if lf.folderParentId == null
+                      then null
+                      else "{${lf.folderParentId}}";
                     prevSiblingInfo = {
                       type = "start";
                       id = null;

--- a/tests/live-folders.nix
+++ b/tests/live-folders.nix
@@ -10,11 +10,20 @@
       enable = true;
       profiles.default = let
         ws = "cccccccc-cccc-4ccc-cccc-cccccccccccc";
+        folder = "dddddddd-dddd-4ddd-dddd-dddddddddddd";
       in {
         spaces."Main" = {
           id = ws;
           name = "Main";
           position = 1;
+        };
+
+        pins."Blogs" = {
+          id = folder;
+          isGroup = true;
+          workspace = ws;
+          position = 19;
+          isFolderCollapsed = true;
         };
 
         liveFolders = {
@@ -26,6 +35,7 @@
             position = 20;
             maxItems = 5;
             folderIcon = "https://nixos.org/favicon.ico";
+            folderParentId = folder;
           };
           "Pull requests" = {
             id = "gh-prs";
@@ -100,18 +110,18 @@
 
       # Session store: folder rows, groups rows, placeholder tabs
       machine.succeed("mozlz4a -d /home/testuser/.config/zen/default/zen-sessions.jsonlz4 /tmp/sessions-live.json")
-      machine.succeed("jq -e '.folders | length == 2' /tmp/sessions-live.json")
+      machine.succeed("jq -e '.folders | length == 3' /tmp/sessions-live.json")
       machine.succeed(
-        "jq -e '.folders[] | select(.id == \"nixos-blog\") | .isLiveFolder == true and .name == \"NixOS blog\" and .pinned == true and .collapsed == true and .emptyTabIds == [\"nixos-blog-empty\"] and .userIcon == \"https://nixos.org/favicon.ico\" and .workspaceId == \"{cccccccc-cccc-4ccc-cccc-cccccccccccc}\"' /tmp/sessions-live.json"
+        "jq -e '.folders[] | select(.id == \"nixos-blog\") | .isLiveFolder == true and .name == \"NixOS blog\" and .pinned == true and .collapsed == true and .emptyTabIds == [\"nixos-blog-empty\"] and .userIcon == \"https://nixos.org/favicon.ico\" and .workspaceId == \"{cccccccc-cccc-4ccc-cccc-cccccccccccc}\" and .parentId == \"{dddddddd-dddd-4ddd-dddd-dddddddddddd}\"' /tmp/sessions-live.json"
       )
       machine.succeed(
-        "jq -e '.folders[] | select(.id == \"gh-prs\") | .isLiveFolder == true and .index == 21' /tmp/sessions-live.json"
+        "jq -e '.folders[] | select(.id == \"gh-prs\") | .isLiveFolder == true and .index == 21 and .parentId == null' /tmp/sessions-live.json"
       )
-      machine.succeed("jq -e '.groups | length == 2' /tmp/sessions-live.json")
+      machine.succeed("jq -e '.groups | length == 3' /tmp/sessions-live.json")
       machine.succeed(
         "jq -e '.groups[] | select(.id == \"nixos-blog\") | .splitView == false and .pinned == true and .color == \"zen-workspace-color\"' /tmp/sessions-live.json"
       )
-      machine.succeed("jq -e '[.tabs[] | select(.zenIsEmpty == true)] | length == 2' /tmp/sessions-live.json")
+      machine.succeed("jq -e '[.tabs[] | select(.zenIsEmpty == true)] | length == 3' /tmp/sessions-live.json")
       machine.succeed(
         "jq -e '.tabs[] | select(.id == \"nixos-blog-empty\") | .groupId == \"nixos-blog\" and .pinned == true and .entries[0].url == \"about:blank\"' /tmp/sessions-live.json"
       )


### PR DESCRIPTION
Closes #376.

Zen lets you drag a live folder inside a regular folder (a pin with `isGroup = true`) using the GUI, but declaratively you could not with specifically live folders: i.e., `parentId` was hardcoded to `null` in the session row.

Adds a `folderParentId` option to live folders:

- `liveFolders.<name>.folderParentId` - pin UUID of a folder pin.
- I added a new assertion that mirrors the `joinedTabs` check: `folderParentId` must reference a declared pin with `isGroup = true`. Zen cannot nest a live folder under another live folder (or at least I could not via the GUI), so the parent must be a usual non-live folder pin.
- I also updated `examples/17-live-folders.nix` with a nested example and extended the `live-folders` test to cover `parentId` (set + null).
